### PR TITLE
Allow DNS port when performing iptables filtering on cloud provider metadata IP

### DIFF
--- a/cmd/sdn-cni-plugin/openshift-sdn_linux.go
+++ b/cmd/sdn-cni-plugin/openshift-sdn_linux.go
@@ -126,9 +126,11 @@ var iptablesCommands = [][]string{
 	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
 	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
 
-	// Block cloud metadata IP
-	{"-A", "OUTPUT", "-d", "169.254.169.254", "-j", "REJECT"},
-	{"-A", "FORWARD", "-d", "169.254.169.254", "-j", "REJECT"},
+	// Block cloud provider metadata IP except DNS
+	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "-d", "169.254.169.254", "!", "--dport", "53", "-j", "REJECT"},
+	{"-A", "OUTPUT", "-p", "udp", "-m", "udp", "-d", "169.254.169.254", "!", "--dport", "53", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "-d", "169.254.169.254", "!", "--dport", "53", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "udp", "-m", "udp", "-d", "169.254.169.254", "!", "--dport", "53", "-j", "REJECT"},
 }
 
 func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -160,9 +160,6 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 		otx.AddFlow("table=30, priority=100, ip, nw_dst=%s, actions=goto_table:90", clusterCIDR)
 	}
 
-	// Link-local traffic
-	otx.AddFlow("table=30, priority=75, ip, nw_dst=169.254.0.0/16, actions=drop")
-
 	// Multicast coming from the VXLAN
 	otx.AddFlow("table=30, priority=50, in_port=1, ip, nw_dst=224.0.0.0/4, actions=goto_table:120")
 	// Multicast coming from local pods


### PR DESCRIPTION
This addresses the bug described [here](https://jira.coreos.com/browse/SDN-493)

We want to allow DNS packets to be routed through the metadata IP as this is sometimes used by internal mechanism to these providers when performing certain networking tasks.   