### PR TITLE
Drop accidentally not-dropped duplicate iptables scripts

### DIFF
--- a/images/kube-proxy/scripts/ip6tables
+++ b/images/kube-proxy/scripts/ip6tables
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/ip6tables "$@"

--- a/images/kube-proxy/scripts/ip6tables-restore
+++ b/images/kube-proxy/scripts/ip6tables-restore
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/ip6tables-restore "$@"

--- a/images/kube-proxy/scripts/ip6tables-save
+++ b/images/kube-proxy/scripts/ip6tables-save
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/ip6tables-save "$@"

--- a/images/kube-proxy/scripts/iptables
+++ b/images/kube-proxy/scripts/iptables
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables "$@"

--- a/images/kube-proxy/scripts/iptables-restore
+++ b/images/kube-proxy/scripts/iptables-restore
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables-restore "$@"

--- a/images/kube-proxy/scripts/iptables-save
+++ b/images/kube-proxy/scripts/iptables-save
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables-save "$@"


### PR DESCRIPTION
#14 originally had duplicate copies of the iptables scripts and was then rewritten to share the ones the sdn image uses but Sally forgot to remove the duplicates and I didn't notice