### PR TITLE
Bug 1740741: Initializing runningPods on SDN bootup for 4.x

### DIFF
--- a/pkg/network/node/multitenant.go
+++ b/pkg/network/node/multitenant.go
@@ -64,7 +64,7 @@ func (mp *multiTenantPlugin) updatePodNetwork(namespace string, oldNetID, netID 
 	// VNID before the service and firewall rules are updated to match. We need
 	// to do the updates as a single transaction (ovs-ofctl --bundle).
 
-	pods, err := mp.node.GetLocalPods(namespace)
+	pods, err := mp.node.GetRunningPods(namespace)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Could not get list of local pods in namespace %q: %v", namespace, err))
 	}

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -133,15 +133,15 @@ func (plugin *OsdnNode) SetupSDN() (bool, map[string]podNetworkInfo, error) {
 	}
 
 	var changed bool
-	var existingPods map[string]podNetworkInfo
+	existingPods, err := plugin.oc.GetPodNetworkInfo()
+	if err != nil {
+		klog.Warningf("[SDN setup] Could not get details of existing pods: %v", err)
+	}
+
 	if err := plugin.alreadySetUp(gwCIDR, clusterNetworkCIDRs); err == nil {
 		klog.V(5).Infof("[SDN setup] no SDN setup required")
 	} else {
 		klog.Infof("[SDN setup] full SDN setup required (%v)", err)
-		existingPods, err = plugin.oc.GetPodNetworkInfo()
-		if err != nil {
-			klog.Warningf("[SDN setup] Could not get details of existing pods: %v", err)
-		}
 		if err := plugin.setup(clusterNetworkCIDRs, localSubnetCIDR, localSubnetGateway, gwCIDR); err != nil {
 			return false, nil, err
 		}


### PR DESCRIPTION
This is a fix for [BUG 1723924](https://bugzilla.redhat.com/show_bug.cgi?id=1723924)

FIX for 4.X on origin, see linked PR's in origin

4.1:

https://github.com/openshift/origin/pull/23537

3.11:

https://github.com/openshift/origin/pull/23522

The problem:

As mentioned in the link above, when the openshift networking process dies, the "podManager" object and its attribute "runningPods" is wiped for memory, which can lead to stateful inconsistencies 
with openflow ports concerning pods from a multicast-enabled namespaces 

The fix:

We now initialize the "podManager" with the initial state of all running pods when the process is booted, as such we will have a synchronized state. 