### PR TITLE
proxy: add a bit more logging around proxy type and sync status

### DIFF
--- a/pkg/network/proxyimpl/hybrid/proxy.go
+++ b/pkg/network/proxyimpl/hybrid/proxy.go
@@ -328,12 +328,13 @@ func (p *HybridProxier) Sync() {
 // We do this so that we can guarantee that changes are applied to both
 // proxies, especially when unidling a newly-awoken service.
 func (p *HybridProxier) syncProxyRules() {
-	klog.V(4).Infof("hybrid proxy: syncProxyRules start")
+	klog.V(2).Infof("hybrid proxy: syncProxyRules start")
 
 	p.mainProxy.SyncProxyRules()
+	klog.V(2).Infof("hybrid proxy: mainProxy.syncProxyRules complete")
 	p.unidlingProxy.SyncProxyRules()
 
-	klog.V(4).Infof("hybrid proxy: syncProxyRules finished")
+	klog.V(2).Infof("hybrid proxy: unidlingProxy.syncProxyRules complete")
 }
 
 // SyncLoop runs periodic work.  This is expected to run as a goroutine or as the main loop of the app.  It does not return.

--- a/pkg/openshift-sdn/proxy.go
+++ b/pkg/openshift-sdn/proxy.go
@@ -101,7 +101,7 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		enableUnidling = true
 		fallthrough
 	case "iptables":
-		klog.V(0).Info("Using iptables Proxier.")
+		klog.V(0).Infof("Using %s Proxier.", sdn.ProxyConfig.Mode)
 		if bindAddr.Equal(net.IPv4zero) {
 			var err error
 			bindAddr, err = getNodeIP(sdn.informers.KubeClient.CoreV1(), hostname)


### PR DESCRIPTION
QE pointed out that it's not easy to see if changing the unidling setting has taken effect. So, add a few simple log lines.