### PR TITLE
Stop building CNI loopback and host-local plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 /openshift-sdn
 /sdn-cni-plugin
 /network-controller
-/loopback
-/host-local
 /kube-proxy
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@ all: build
 
 GO_BUILD_PACKAGES = \
     ./cmd/... \
-    ./vendor/github.com/containernetworking/plugins/plugins/ipam/host-local \
-    ./vendor/github.com/containernetworking/plugins/plugins/main/loopback \
     ./vendor/k8s.io/kubernetes/cmd/kube-proxy
 
 # Include the library makefile

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -6,8 +6,6 @@ RUN make build --warn-undefined-variables
 FROM centos:7
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/openshift-sdn
-COPY --from=builder /go/src/github.com/openshift/sdn/loopback /opt/cni/bin/
-COPY --from=builder /go/src/github.com/openshift/sdn/host-local /opt/cni/bin/
 
 RUN INSTALL_PKGS=" \
       openvswitch2.11 container-selinux socat ethtool nmap-ncat \

--- a/images/node/Dockerfile.rhel
+++ b/images/node/Dockerfile.rhel
@@ -6,8 +6,6 @@ RUN make build --warn-undefined-variables
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/openshift-sdn
-COPY --from=builder /go/src/github.com/openshift/sdn/loopback /opt/cni/bin/
-COPY --from=builder /go/src/github.com/openshift/sdn/host-local /opt/cni/bin/
 
 RUN INSTALL_PKGS=" \
       openvswitch2.11 container-selinux socat ethtool nmap-ncat \

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -45,9 +45,6 @@ import (
 	"github.com/openshift/sdn/pkg/network/node/ovs"
 )
 
-const hostLocalDataDir = "/var/lib/cni/networks"
-const cniBinDir = "/opt/cni/bin"
-
 type osdnPolicy interface {
 	Name() string
 	Start(node *OsdnNode) error

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -34,6 +34,8 @@ import (
 
 const (
 	podInterfaceName = "eth0"
+	hostLocalDataDir = "/var/lib/cni/networks"
+	cniPluginsBinDir = "/host/opt/cni/bin"
 )
 
 type podHandler interface {
@@ -347,7 +349,7 @@ func createIPAMArgs(netnsPath string, action cniserver.CNICommand, id string) *i
 		ContainerID: id,
 		NetNS:       netnsPath,
 		IfName:      podInterfaceName,
-		Path:        cniBinDir,
+		Path:        cniPluginsBinDir,
 	}
 }
 
@@ -358,7 +360,7 @@ func (m *podManager) ipamAdd(netnsPath string, id string) (*current.Result, net.
 	}
 
 	args := createIPAMArgs(netnsPath, cniserver.CNI_ADD, id)
-	r, err := invoke.ExecPluginWithResult(cniBinDir+"/host-local", m.ipamConfig, args)
+	r, err := invoke.ExecPluginWithResult(cniPluginsBinDir+"/host-local", m.ipamConfig, args)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to run CNI IPAM ADD: %v", err)
 	}
@@ -378,7 +380,7 @@ func (m *podManager) ipamAdd(netnsPath string, id string) (*current.Result, net.
 // Run CNI IPAM release for the container
 func (m *podManager) ipamDel(id string) error {
 	args := createIPAMArgs("", cniserver.CNI_DEL, id)
-	err := invoke.ExecPluginWithoutResult(cniBinDir+"/host-local", m.ipamConfig, args)
+	err := invoke.ExecPluginWithoutResult(cniPluginsBinDir+"/host-local", m.ipamConfig, args)
 	if err != nil {
 		return fmt.Errorf("failed to run CNI IPAM DEL: %v", err)
 	}


### PR DESCRIPTION
With https://github.com/openshift/cluster-network-operator/pull/288 merged, openshift-sdn gets its upstream CNI plugins from the container-networking-plugins image, so we can stop building them.

/cc @squeed