### PR TITLE
Add support for IPBlocks

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -525,6 +525,16 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 				npp.watchesPods = true
 				peerFlows = append(peerFlows, np.selectPodsFromNamespaces(peer.NamespaceSelector, peer.PodSelector)...)
 			}
+
+			if peer.IPBlock != nil {
+				if peer.IPBlock.Except != nil {
+					// Currently IPBlocks with except rules are skipped.
+					klog.Warningf("IPBlocks with except rules are not supported (NetworkPolicy [%s], Namespace [%s])", policy.Name, policy.Namespace)
+				} else {
+					// Network Policy has ipBlocks, allow traffic from those ips.
+					peerFlows = append(peerFlows, fmt.Sprintf("ip, nw_src=%s, ", peer.IPBlock.CIDR))
+				}
+			}
 		}
 		for _, destFlow := range destFlows {
 			for _, peerFlow := range peerFlows {


### PR DESCRIPTION
Add support for IPBlocks in network policy.

ipBlocks in NetworkPolicies allow us to specify CIDR ranges
as ingress sources or egress destinations. Generally these
are cluster-external IPs and will allow you to filter incoming
packets based on the source-ip.

This PR implements ingress ipBlocks in NetworkPolicies.
Support for ipBlocks with except rules will be added via separate PR.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>