### PR TITLE
Bug 1745028: adding support for undefined port in networkpolicy definition

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -419,8 +419,8 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 			}
 			var portNum int
 			if port.Port == nil {
-				// FIXME: implement this?
-				return nil, fmt.Errorf("port fields with no port value are not implemented")
+				portFlows = append(portFlows, fmt.Sprintf("%s, ", protocol))
+				continue
 			} else if port.Port.Type != intstr.Int {
 				// FIXME: implement this?
 				return nil, fmt.Errorf("named port values (%q) are not implemented", port.Port.StrVal)


### PR DESCRIPTION
Hi

I am not sure if this is all we want to do, there are many more `FIXME`'s in this block of code. How about named ports, should we support that? What about the comments referencing "validation"?

Please let me know if you'd like me to update the PR with additional fixes for that as well? 

/assign @danwinship @squeed 