### PR TITLE
Bug 1751954: images: disable cgo

### DIFF
--- a/images/node/Dockerfile.rhel
+++ b/images/node/Dockerfile.rhel
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/sdn
 COPY . .
-RUN make build --warn-undefined-variables
+RUN CGO_ENABLED=0 make build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/


### PR DESCRIPTION
We're still seeing random coredumps / segfaults on rhel7 binaries on rhel8. Disable cgo again.