### PR TITLE
Bug 1752636: networkpolicy: add a namespaceSelector cache

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -37,6 +37,9 @@ type networkPolicyPlugin struct {
 	kNamespaces map[string]corev1.Namespace
 	pods        map[ktypes.UID]corev1.Pod
 
+	// namespaceSelector match cache; see selectNamespacesInternal
+	nsMatchCache map[string]map[string]uint32
+
 	runner *async.BoundedFrequencyRunner
 }
 
@@ -72,6 +75,8 @@ func NewNetworkPolicyPlugin() osdnPolicy {
 		namespaces:  make(map[uint32]*npNamespace),
 		kNamespaces: make(map[string]corev1.Namespace),
 		pods:        make(map[ktypes.UID]corev1.Pod),
+
+		nsMatchCache: make(map[string]map[string]uint32),
 	}
 }
 
@@ -163,6 +168,7 @@ func (np *networkPolicyPlugin) AddNetNamespace(netns *networkv1.NetNamespace) {
 		return
 	}
 
+	np.flushNSMatchCache()
 	np.namespaces[netns.NetID] = &npNamespace{
 		name:     netns.NetName,
 		vnid:     netns.NetID,
@@ -184,6 +190,7 @@ func (np *networkPolicyPlugin) DeleteNetNamespace(netns *networkv1.NetNamespace)
 	defer np.lock.Unlock()
 
 	if npns, exists := np.namespaces[netns.NetID]; exists {
+		np.flushNSMatchCache()
 		if npns.inUse {
 			npns.inUse = false
 			// We call syncNamespaceFlows() not syncNamespace() because it
@@ -299,8 +306,36 @@ func (np *networkPolicyPlugin) SyncVNIDRules() {
 	}
 }
 
+// Match namespaces against a selector, using a cache so that, eg, when a new Namespace is
+// added, we only figure out if it matches "name: default" once, rather than recomputing
+// the set of namespaces that match that selector for every single "allow-from-default"
+// policy in the cluster.
+//
+// Yes, if a selector matches against multiple labels then the order they appear in
+// cacheKey here is non-deterministic, but that just means that, eg, we might compute the
+// results twice rather than just once, and twice is still better than 10,000 times.
+func (np *networkPolicyPlugin) selectNamespacesInternal(sel labels.Selector) map[string]uint32 {
+	cacheKey := sel.String()
+	namespaces, wasCached := np.nsMatchCache[cacheKey]
+	if !wasCached {
+		namespaces = make(map[string]uint32)
+		for vnid, ns := range np.namespaces {
+			if kns, exists := np.kNamespaces[ns.name]; exists {
+				if sel.Matches(labels.Set(kns.Labels)) {
+					namespaces[ns.name] = vnid
+				}
+			}
+		}
+		np.nsMatchCache[cacheKey] = namespaces
+	}
+	return namespaces
+}
+
+func (np *networkPolicyPlugin) flushNSMatchCache() {
+	np.nsMatchCache = make(map[string]map[string]uint32)
+}
+
 func (np *networkPolicyPlugin) selectPodsFromNamespaces(nsLabelSel, podLabelSel *metav1.LabelSelector) []string {
-	namespaces := make(map[string]uint32)
 	var peerFlows []string
 
 	nsSel, err := metav1.LabelSelectorAsSelector(nsLabelSel)
@@ -317,13 +352,7 @@ func (np *networkPolicyPlugin) selectPodsFromNamespaces(nsLabelSel, podLabelSel 
 		return nil
 	}
 
-	for vnid, ns := range np.namespaces {
-		if kns, exists := np.kNamespaces[ns.name]; exists {
-			if nsSel.Matches(labels.Set(kns.Labels)) {
-				namespaces[ns.name] = vnid
-			}
-		}
-	}
+	namespaces := np.selectNamespacesInternal(nsSel)
 	for _, pod := range np.pods {
 		vnid, exists := namespaces[pod.Namespace]
 		if exists && podSel.Matches(labels.Set(pod.Labels)) {
@@ -343,12 +372,10 @@ func (np *networkPolicyPlugin) selectNamespaces(lsel *metav1.LabelSelector) []st
 		utilruntime.HandleError(fmt.Errorf("ValidateNetworkPolicy() failure! Invalid NamespaceSelector: %v", err))
 		return peerFlows
 	}
-	for vnid, ns := range np.namespaces {
-		if kns, exists := np.kNamespaces[ns.name]; exists {
-			if sel.Matches(labels.Set(kns.Labels)) {
-				peerFlows = append(peerFlows, fmt.Sprintf("reg0=%d, ", vnid))
-			}
-		}
+
+	namespaces := np.selectNamespacesInternal(sel)
+	for _, vnid := range namespaces {
+		peerFlows = append(peerFlows, fmt.Sprintf("reg0=%d, ", vnid))
 	}
 	return peerFlows
 }
@@ -594,6 +621,7 @@ func (np *networkPolicyPlugin) handleAddOrUpdateNamespace(obj, _ interface{}, ev
 	defer np.lock.Unlock()
 
 	np.kNamespaces[ns.Name] = *ns
+	np.flushNSMatchCache()
 	np.refreshNetworkPolicies(refreshForNamespaces)
 }
 
@@ -605,6 +633,7 @@ func (np *networkPolicyPlugin) handleDeleteNamespace(obj interface{}) {
 	defer np.lock.Unlock()
 
 	delete(np.kNamespaces, ns.Name)
+	np.flushNSMatchCache()
 	np.refreshNetworkPolicies(refreshForNamespaces)
 }
 

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -12,7 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ktypes "k8s.io/apimachinery/pkg/types"
@@ -141,9 +140,6 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 
 	policies, err := np.node.kClient.NetworkingV1().NetworkPolicies(corev1.NamespaceAll).List(metav1.ListOptions{})
 	if err != nil {
-		if kapierrs.IsForbidden(err) {
-			utilruntime.HandleError(fmt.Errorf("unable to query NetworkPolicies (%v) - please ensure your nodes have access to view NetworkPolicy", err))
-		}
 		return err
 	}
 	for _, policy := range policies.Items {
@@ -340,21 +336,21 @@ func (np *networkPolicyPlugin) selectPodsFromNamespaces(nsLabelSel, podLabelSel 
 }
 
 func (np *networkPolicyPlugin) selectNamespaces(lsel *metav1.LabelSelector) []string {
-	var vnids []string
+	var peerFlows []string
 	sel, err := metav1.LabelSelectorAsSelector(lsel)
 	if err != nil {
 		// Shouldn't happen
 		utilruntime.HandleError(fmt.Errorf("ValidateNetworkPolicy() failure! Invalid NamespaceSelector: %v", err))
-		return vnids
+		return peerFlows
 	}
 	for vnid, ns := range np.namespaces {
 		if kns, exists := np.kNamespaces[ns.name]; exists {
 			if sel.Matches(labels.Set(kns.Labels)) {
-				vnids = append(vnids, fmt.Sprintf("reg0=%d, ", vnid))
+				peerFlows = append(peerFlows, fmt.Sprintf("reg0=%d, ", vnid))
 			}
 		}
 	}
-	return vnids
+	return peerFlows
 }
 
 func (np *networkPolicyPlugin) selectPods(npns *npNamespace, lsel *metav1.LabelSelector) []string {
@@ -383,9 +379,9 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 		}
 	}
 	if !affectsIngress {
-		// The rest of this file assumes that all policies affect ingress: a policy that
-		// only affects egress is, for our purposes, equivalent to one that affects
-		// ingress but does not select any pods.
+		// The rest of this function assumes that all policies affect ingress: a
+		// policy that only affects egress is, for our purposes, equivalent to one
+		// that affects ingress but does not select any pods.
 		npp.selectedIPs = []string{""}
 		return npp, nil
 	}
@@ -414,7 +410,7 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 			} else if *port.Protocol == corev1.ProtocolTCP || *port.Protocol == corev1.ProtocolUDP || *port.Protocol == corev1.ProtocolSCTP {
 				protocol = strings.ToLower(string(*port.Protocol))
 			} else {
-				// FIXME: validation should catch this
+				// upstream is unlikely to add any more protocol values, but just in case...
 				return nil, fmt.Errorf("policy specifies unrecognized protocol %q", *port.Protocol)
 			}
 			var portNum int
@@ -422,14 +418,9 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 				portFlows = append(portFlows, fmt.Sprintf("%s, ", protocol))
 				continue
 			} else if port.Port.Type != intstr.Int {
-				// FIXME: implement this?
 				return nil, fmt.Errorf("named port values (%q) are not implemented", port.Port.StrVal)
 			} else {
 				portNum = int(port.Port.IntVal)
-				if portNum < 0 || portNum > 0xFFFF {
-					// FIXME: validation should catch this
-					return nil, fmt.Errorf("port value out of bounds %q", port.Port.IntVal)
-				}
 			}
 			portFlows = append(portFlows, fmt.Sprintf("%s, tp_dst=%d, ", protocol, portNum))
 		}

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -1,0 +1,425 @@
+package node
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+
+	networkv1 "github.com/openshift/api/network/v1"
+)
+
+func addNamespace(np *networkPolicyPlugin, name string, vnid uint32, labels map[string]string) {
+	np.handleAddOrUpdateNamespace(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}, nil, watch.Added)
+	np.vnids.handleAddOrUpdateNetNamespace(&networkv1.NetNamespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		NetName: name,
+		NetID:   vnid,
+	}, nil, watch.Added)
+}
+
+func uid(npns *npNamespace, name string) ktypes.UID {
+	return ktypes.UID(name + "-" + npns.name)
+}
+
+func assertPolicies(npns *npNamespace, nPolicies int, matches map[string]*npPolicy) error {
+	var matched []string
+	for _, npp := range npns.policies {
+		match := matches[npp.policy.Name]
+		if match == nil {
+			continue
+		}
+		matched = append(matched, npp.policy.Name)
+		if npp.watchesNamespaces != match.watchesNamespaces {
+			return fmt.Errorf("policy %q in %q has incorrect watchesNamespaces %t", npp.policy.Name, npns.name, npp.watchesNamespaces)
+		}
+		if npp.watchesPods != match.watchesPods {
+			return fmt.Errorf("policy %q in %q has incorrect watchesPods %t", npp.policy.Name, npns.name, npp.watchesPods)
+		}
+
+		nppFlows := sets.NewString(npp.flows...)
+		matchFlows := sets.NewString()
+		for _, flow := range match.flows {
+			if !strings.HasSuffix(flow, ", ") {
+				flow = flow + ", "
+			}
+			matchFlows.Insert(flow)
+		}
+		if !nppFlows.Equal(matchFlows) {
+			return fmt.Errorf("policy %q in %q has incorrect flows; expected %#v, got %#v", npp.policy.Name, npns.name, match.flows, npp.flows)
+		}
+	}
+
+	if len(matches) != len(matched) {
+		return fmt.Errorf("expected namespace %q to match %d policies but only found %d %v", npns.name, len(matches), len(matched), matched)
+	}
+	if len(npns.policies) != nPolicies {
+		return fmt.Errorf("expected namespace %q to have %d policies but it has %d", npns.name, nPolicies, len(npns.policies))
+	}
+
+	return nil
+}
+
+func clientIP(npns *npNamespace) string {
+	return fmt.Sprintf("10.%d.0.2", npns.vnid)
+}
+
+func serverIP(npns *npNamespace) string {
+	return fmt.Sprintf("10.%d.0.3", npns.vnid)
+}
+
+func addPods(np *networkPolicyPlugin, npns *npNamespace) {
+	np.handleAddOrUpdatePod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: npns.name,
+			Name:      "client",
+			UID:       uid(npns, "client"),
+			Labels: map[string]string{
+				"kind": "client",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: clientIP(npns),
+		},
+	}, nil, watch.Added)
+	np.handleAddOrUpdatePod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: npns.name,
+			Name:      "server",
+			UID:       uid(npns, "server"),
+			Labels: map[string]string{
+				"kind": "server",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: serverIP(npns),
+		},
+	}, nil, watch.Added)
+}
+
+func TestNetworkPolicy(t *testing.T) {
+	np := &networkPolicyPlugin{
+		namespaces:  make(map[uint32]*npNamespace),
+		kNamespaces: make(map[string]corev1.Namespace),
+		pods:        make(map[ktypes.UID]corev1.Pod),
+	}
+	np.vnids = newNodeVNIDMap(np, nil)
+
+	// Create some Namespaces
+	addNamespace(np, "default", 0, map[string]string{"default": "true"})
+	addNamespace(np, "one", 1, map[string]string{"parity": "odd"})
+	addNamespace(np, "two", 2, map[string]string{"parity": "even", "prime": "true"})
+	addNamespace(np, "three", 3, map[string]string{"parity": "odd", "prime": "true"})
+	addNamespace(np, "four", 4, map[string]string{"parity": "even"})
+	addNamespace(np, "five", 5, map[string]string{"parity": "odd", "prime": "true"})
+
+	// Add allow-from-self and allow-from-default policies to all
+	for _, npns := range np.namespaces {
+		np.handleAddOrUpdateNetworkPolicy(&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-from-self",
+				UID:       uid(npns, "allow-from-self"),
+				Namespace: npns.name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{
+					From: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{},
+					}},
+				}},
+			},
+		}, nil, watch.Added)
+
+		np.handleAddOrUpdateNetworkPolicy(&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-from-default",
+				UID:       uid(npns, "allow-from-default"),
+				Namespace: npns.name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{
+					From: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"default": "true",
+							},
+						},
+					}},
+				}},
+			},
+		}, nil, watch.Added)
+	}
+
+	// Each namespace should now have 2 policies, each with a single flow
+	for _, npns := range np.namespaces {
+		err := assertPolicies(npns, 2, map[string]*npPolicy{
+			"allow-from-self": {
+				watchesNamespaces: false,
+				watchesPods:       false,
+				flows: []string{
+					fmt.Sprintf("reg0=%d", npns.vnid),
+				},
+			},
+			"allow-from-default": {
+				watchesNamespaces: true,
+				watchesPods:       false,
+				flows: []string{
+					"reg0=0",
+				},
+			},
+		})
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+
+	// Add two pods to each namespace
+	for _, npns := range np.namespaces {
+		addPods(np, npns)
+
+		// There are no pod-selecting policies yet, so nothing should have changed
+		err := assertPolicies(npns, 2, nil)
+		if err != nil {
+			t.Error(err.Error())
+		}
+
+		np.handleAddOrUpdateNetworkPolicy(&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-client-to-server",
+				UID:       uid(npns, "allow-client-to-server"),
+				Namespace: npns.name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"kind": "server",
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{
+					From: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kind": "client",
+							},
+						},
+					}},
+				}},
+			},
+		}, nil, watch.Added)
+
+		err = assertPolicies(npns, 3, map[string]*npPolicy{
+			"allow-client-to-server": {
+				watchesNamespaces: false,
+				watchesPods:       true,
+				flows: []string{
+					fmt.Sprintf("ip, nw_dst=%s, reg0=%d, ip, nw_src=%s", serverIP(npns), npns.vnid, clientIP(npns)),
+				},
+			},
+		})
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+
+	npns1 := np.namespaces[1]
+
+	// Allow all pods in even-numbered namespaces to connect to any pod in namespace "one"
+	np.handleAddOrUpdateNetworkPolicy(&networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-from-even",
+			UID:       uid(npns1, "allow-from-even"),
+			Namespace: "one",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"parity": "even",
+						},
+					},
+				}},
+			}},
+		},
+	}, nil, watch.Added)
+
+	err := assertPolicies(npns1, 4, map[string]*npPolicy{
+		"allow-from-even": {
+			watchesNamespaces: true,
+			watchesPods:       false,
+			flows: []string{
+				"reg0=2",
+				"reg0=4",
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// Allow client pods in odd prime namespaces to connect to the server in namespace "one"
+	np.handleAddOrUpdateNetworkPolicy(&networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-from-odd-primes",
+			UID:       uid(npns1, "allow-from-odd-primes"),
+			Namespace: "one",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kind": "server",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"parity": "odd",
+							"prime":  "true",
+						},
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kind": "client",
+						},
+					},
+				}},
+			}},
+		},
+	}, nil, watch.Added)
+
+	err = assertPolicies(npns1, 5, map[string]*npPolicy{
+		"allow-from-odd-primes": {
+			watchesNamespaces: true,
+			watchesPods:       true,
+			flows: []string{
+				fmt.Sprintf("ip, nw_dst=%s, reg0=3, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[3])),
+				fmt.Sprintf("ip, nw_dst=%s, reg0=5, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[5])),
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// add some more namespaces
+	addNamespace(np, "six", 6, map[string]string{"parity": "even"})
+	addPods(np, np.namespaces[6])
+	addNamespace(np, "seven", 7, map[string]string{"parity": "odd", "prime": "true"})
+	addPods(np, np.namespaces[7])
+	addNamespace(np, "eight", 8, map[string]string{"parity": "even"})
+	addPods(np, np.namespaces[8])
+	addNamespace(np, "nine", 9, map[string]string{"parity": "odd"})
+	addPods(np, np.namespaces[9])
+
+	// Now reassert the full set of matches for each namespace
+	for vnid, npns := range np.namespaces {
+		switch vnid {
+		case 1:
+			err := assertPolicies(npns, 5, map[string]*npPolicy{
+				"allow-from-self": {
+					watchesNamespaces: false,
+					watchesPods:       false,
+					flows: []string{
+						"reg0=1",
+					},
+				},
+				"allow-from-default": {
+					watchesNamespaces: true,
+					watchesPods:       false,
+					flows: []string{
+						"reg0=0",
+					},
+				},
+				"allow-client-to-server": {
+					watchesNamespaces: false,
+					watchesPods:       true,
+					flows: []string{
+						fmt.Sprintf("ip, nw_dst=%s, reg0=1, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
+					},
+				},
+				"allow-from-even": {
+					watchesNamespaces: true,
+					watchesPods:       false,
+					flows: []string{
+						"reg0=2",
+						"reg0=4",
+						"reg0=6",
+						"reg0=8",
+					},
+				},
+				"allow-from-odd-primes": {
+					watchesNamespaces: true,
+					watchesPods:       true,
+					flows: []string{
+						fmt.Sprintf("ip, nw_dst=%s, reg0=3, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[3])),
+						fmt.Sprintf("ip, nw_dst=%s, reg0=5, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[5])),
+						fmt.Sprintf("ip, nw_dst=%s, reg0=7, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[7])),
+						// but NOT from reg0=9
+					},
+				},
+			})
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case 0, 2, 3, 4, 5:
+			err := assertPolicies(npns, 3, map[string]*npPolicy{
+				"allow-from-self": {
+					watchesNamespaces: false,
+					watchesPods:       false,
+					flows: []string{
+						fmt.Sprintf("reg0=%d", vnid),
+					},
+				},
+				"allow-from-default": {
+					watchesNamespaces: true,
+					watchesPods:       false,
+					flows: []string{
+						"reg0=0",
+					},
+				},
+				"allow-client-to-server": {
+					watchesNamespaces: false,
+					watchesPods:       true,
+					flows: []string{
+						fmt.Sprintf("ip, nw_dst=%s, reg0=%d, ip, nw_src=%s", serverIP(npns), vnid, clientIP(npns)),
+					},
+				},
+			})
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case 6, 7, 8, 9:
+			err := assertPolicies(npns, 0, nil)
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		default:
+			t.Errorf("Unexpected namespace %d / %s", vnid, npns.name)
+		}
+	}
+}


### PR DESCRIPTION
In systems with very many namespaces and very many network policies, simply adding new namespaces becomes extremely slow, because, eg, every time you add a new namespace, it needs to compare 10,000 "allow-from-default-namespace" policies against it to see if the namespaceSelectors match.

This fixes that by adding a cache of namespaceSelectors. To avoid having to do complicated cache management, we just empty out the cache any time any Namespace changes. It seems to help a lot; https://github.com/danwinship/sdn/commit/1a5dfd65 has an test on top of this. With the cache, on my laptop, it takes 21ms for the setup and 434ms to complete. With the cache disabled (eg, comment out the `np.nsMatchCache[cacheKey] = namespaces` line in networkpolicy.go), it takes 61ms for the setup and 7.55s to complete.

I wanted to make that into an actual unit test, where it would fail if the test seemed to be taking too long, but that wasn't working well. We can't just check the run time, because different hosts, different loads, etc. I was hoping I could compare the time that the early part of the loop took against the time the later part of the loop took, and use that to figure out whether we were O(n^2) or O(2^n). And it almost worked, except that garbage collection and stuff means that sometimes one of the specific intervals I was checking would be very non-representative and it wouldn't work. So I didn't bother actually adding the test. But the cache does work, and we can have QE test this.
