### PR TITLE
further NetworkPolicy caching fixes

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -41,7 +41,7 @@ type networkPolicyPlugin struct {
 	// for all flow-generating methods
 	namespaces map[uint32]*npNamespace
 	// nsMatchCache caches matches for namespaceSelectors; see selectNamespaceInternal
-	nsMatchCache map[string]map[string]uint32
+	nsMatchCache map[string]*npCacheEntry
 
 	pods map[ktypes.UID]corev1.Pod
 }
@@ -70,6 +70,12 @@ type npPolicy struct {
 	selectedIPs []string
 }
 
+// npCacheEntry caches information about matches for a LabelSelector
+type npCacheEntry struct {
+	selector labels.Selector
+	matches  map[string]uint32
+}
+
 type refreshForType string
 
 const (
@@ -83,7 +89,7 @@ func NewNetworkPolicyPlugin() osdnPolicy {
 		namespacesByName: make(map[string]*npNamespace),
 		pods:             make(map[ktypes.UID]corev1.Pod),
 
-		nsMatchCache: make(map[string]map[string]uint32),
+		nsMatchCache: make(map[string]*npCacheEntry),
 	}
 }
 
@@ -190,7 +196,7 @@ func (np *networkPolicyPlugin) AddNetNamespace(netns *networkv1.NetNamespace) {
 
 	npns.gotNetNamespace = true
 	if npns.gotNamespace {
-		np.flushNSMatchCache()
+		np.updateMatchCache(npns)
 		np.refreshNetworkPolicies(refreshForNamespaces)
 	}
 }
@@ -221,9 +227,10 @@ func (np *networkPolicyPlugin) DeleteNetNamespace(netns *networkv1.NetNamespace)
 	delete(np.namespaces, netns.NetID)
 	npns.gotNetNamespace = false
 
-	// We don't need to call flushNSMatchCache or refreshNetworkPolicies here; if the
-	// VNID doesn't get reused then the stale cache entries/flows won't hurt anything,
-	// and if it does get reused then things will be cleaned up then.
+	// We don't need to call refreshNetworkPolicies here; if the VNID doesn't get
+	// reused then the stale flows won't hurt anything, and if it does get reused then
+	// things will be cleaned up then. However, we do have to clean up the cache.
+	np.updateMatchCache(npns)
 }
 
 func (np *networkPolicyPlugin) GetVNID(namespace string) (uint32, error) {
@@ -339,23 +346,39 @@ func (np *networkPolicyPlugin) SyncVNIDRules() {
 // Yes, if a selector matches against multiple labels then the order they appear in
 // cacheKey here is non-deterministic, but that just means that, eg, we might compute the
 // results twice rather than just once, and twice is still better than 10,000 times.
-func (np *networkPolicyPlugin) selectNamespacesInternal(sel labels.Selector) map[string]uint32 {
-	cacheKey := sel.String()
-	namespaces, wasCached := np.nsMatchCache[cacheKey]
-	if !wasCached {
-		namespaces = make(map[string]uint32)
+func (np *networkPolicyPlugin) selectNamespacesInternal(selector labels.Selector) map[string]uint32 {
+	cacheKey := selector.String()
+	match := np.nsMatchCache[cacheKey]
+	if match == nil {
+		match = &npCacheEntry{selector: selector, matches: make(map[string]uint32)}
 		for vnid, npns := range np.namespaces {
-			if npns.gotNamespace && sel.Matches(labels.Set(npns.labels)) {
-				namespaces[npns.name] = vnid
+			if npns.gotNamespace && selector.Matches(labels.Set(npns.labels)) {
+				match.matches[npns.name] = vnid
 			}
 		}
-		np.nsMatchCache[cacheKey] = namespaces
+		np.nsMatchCache[cacheKey] = match
 	}
-	return namespaces
+	return match.matches
 }
 
-func (np *networkPolicyPlugin) flushNSMatchCache() {
-	np.nsMatchCache = make(map[string]map[string]uint32)
+func (np *networkPolicyPlugin) updateMatchCache(npns *npNamespace) {
+	for _, match := range np.nsMatchCache {
+		if npns.gotNamespace && npns.gotNetNamespace && match.selector.Matches(labels.Set(npns.labels)) {
+			match.matches[npns.name] = npns.vnid
+		} else {
+			delete(match.matches, npns.name)
+		}
+	}
+}
+
+func (np *networkPolicyPlugin) flushMatchCache(lsel *metav1.LabelSelector) {
+	selector, err := metav1.LabelSelectorAsSelector(lsel)
+	if err != nil {
+		// Shouldn't happen
+		utilruntime.HandleError(fmt.Errorf("ValidateNetworkPolicy() failure! Invalid NamespaceSelector: %v", err))
+		return
+	}
+	delete(np.nsMatchCache, selector.String())
 }
 
 func (np *networkPolicyPlugin) selectPodsFromNamespaces(nsLabelSel, podLabelSel *metav1.LabelSelector) []string {
@@ -517,6 +540,21 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 	return npp, nil
 }
 
+// Cleans up after a NetworkPolicy that is being deleted
+func (np *networkPolicyPlugin) cleanupNetworkPolicy(policy *networkingv1.NetworkPolicy) {
+	for _, rule := range policy.Spec.Ingress {
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil {
+				if len(peer.NamespaceSelector.MatchLabels) != 0 || len(peer.NamespaceSelector.MatchExpressions) != 0 {
+					// This is overzealous; there may still be other policies
+					// with the same selector. But it's simple.
+					np.flushMatchCache(peer.NamespaceSelector)
+				}
+			}
+		}
+	}
+}
+
 func (np *networkPolicyPlugin) updateNetworkPolicy(npns *npNamespace, policy *networkingv1.NetworkPolicy) bool {
 	npp, err := np.parseNetworkPolicy(npns, policy)
 	if err != nil {
@@ -575,6 +613,7 @@ func (np *networkPolicyPlugin) handleDeleteNetworkPolicy(obj interface{}) {
 	defer np.lock.Unlock()
 
 	if npns, exists := np.namespaces[vnid]; exists {
+		np.cleanupNetworkPolicy(policy)
 		delete(npns.policies, policy.UID)
 		if npns.inUse {
 			np.syncNamespace(npns)
@@ -656,7 +695,7 @@ func (np *networkPolicyPlugin) handleAddOrUpdateNamespace(obj, _ interface{}, ev
 
 	npns.gotNamespace = true
 	if npns.gotNetNamespace {
-		np.flushNSMatchCache()
+		np.updateMatchCache(npns)
 		np.refreshNetworkPolicies(refreshForNamespaces)
 	}
 }
@@ -676,9 +715,10 @@ func (np *networkPolicyPlugin) handleDeleteNamespace(obj interface{}) {
 	delete(np.namespacesByName, ns.Name)
 	npns.gotNamespace = false
 
-	// We don't need to call flushNSMatchCache or refreshNetworkPolicies here; if the
-	// VNID doesn't get reused then the stale cache entries/flows won't hurt anything,
-	// and if it does get reused then things will be cleaned up then.
+	// We don't need to call refreshNetworkPolicies here; if the VNID doesn't get
+	// reused then the stale flows won't hurt anything, and if it does get reused then
+	// things will be cleaned up then. However, we do have to clean up the cache.
+	np.updateMatchCache(npns)
 }
 
 func (np *networkPolicyPlugin) refreshNetworkPolicies(refreshFor refreshForType) {

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -29,18 +29,21 @@ import (
 )
 
 type networkPolicyPlugin struct {
-	node  *OsdnNode
-	vnids *nodeVNIDMap
+	node   *OsdnNode
+	vnids  *nodeVNIDMap
+	runner *async.BoundedFrequencyRunner
 
-	lock        sync.Mutex
-	namespaces  map[uint32]*npNamespace
-	kNamespaces map[string]corev1.Namespace
-	pods        map[ktypes.UID]corev1.Pod
-
-	// namespaceSelector match cache; see selectNamespacesInternal
+	lock sync.Mutex
+	// namespacesByName includes every Namespace, including ones that we haven't seen
+	// a NetNamespace for, and is only used in the informer-related methods.
+	namespacesByName map[string]*npNamespace
+	// namespaces includes only the namespaces that we have a VNID for, and is used
+	// for all flow-generating methods
+	namespaces map[uint32]*npNamespace
+	// nsMatchCache caches matches for namespaceSelectors; see selectNamespaceInternal
 	nsMatchCache map[string]map[string]uint32
 
-	runner *async.BoundedFrequencyRunner
+	pods map[ktypes.UID]corev1.Pod
 }
 
 // npNamespace tracks NetworkPolicy-related data for a Namespace
@@ -50,7 +53,11 @@ type npNamespace struct {
 	inUse bool
 	dirty bool
 
+	labels   map[string]string
 	policies map[ktypes.UID]*npPolicy
+
+	gotNamespace    bool
+	gotNetNamespace bool
 }
 
 // npPolicy is a parsed version of a single NetworkPolicy object
@@ -72,9 +79,9 @@ const (
 
 func NewNetworkPolicyPlugin() osdnPolicy {
 	return &networkPolicyPlugin{
-		namespaces:  make(map[uint32]*npNamespace),
-		kNamespaces: make(map[string]corev1.Namespace),
-		pods:        make(map[ktypes.UID]corev1.Pod),
+		namespaces:       make(map[uint32]*npNamespace),
+		namespacesByName: make(map[string]*npNamespace),
+		pods:             make(map[ktypes.UID]corev1.Pod),
 
 		nsMatchCache: make(map[string]map[string]uint32),
 	}
@@ -131,15 +138,16 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 		return err
 	}
 	for _, ns := range namespaces.Items {
-		np.kNamespaces[ns.Name] = ns
+		npns := newNPNamespace(ns.Name)
+		npns.labels = ns.Labels
+		npns.gotNamespace = true
+		np.namespacesByName[ns.Name] = npns
 
 		if vnid, err := np.vnids.WaitAndGetVNID(ns.Name); err == nil {
-			np.namespaces[vnid] = &npNamespace{
-				name:     ns.Name,
-				vnid:     vnid,
-				inUse:    inUseVNIDs.Has(int(vnid)),
-				policies: make(map[ktypes.UID]*npPolicy),
-			}
+			npns.vnid = vnid
+			npns.inUse = inUseVNIDs.Has(int(vnid))
+			npns.gotNetNamespace = true
+			np.namespaces[vnid] = npns
 		}
 	}
 
@@ -159,21 +167,31 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 	return nil
 }
 
+func newNPNamespace(name string) *npNamespace {
+	return &npNamespace{
+		name:     name,
+		policies: make(map[ktypes.UID]*npPolicy),
+	}
+}
+
 func (np *networkPolicyPlugin) AddNetNamespace(netns *networkv1.NetNamespace) {
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	if _, exists := np.namespaces[netns.NetID]; exists {
-		klog.Warningf("Got AddNetNamespace for already-existing namespace %s (%d)", netns.NetName, netns.NetID)
-		return
+	npns := np.namespacesByName[netns.NetName]
+	if npns == nil {
+		npns = newNPNamespace(netns.NetName)
+		np.namespacesByName[netns.NetName] = npns
 	}
 
-	np.flushNSMatchCache()
-	np.namespaces[netns.NetID] = &npNamespace{
-		name:     netns.NetName,
-		vnid:     netns.NetID,
-		inUse:    false,
-		policies: make(map[ktypes.UID]*npPolicy),
+	npns.vnid = netns.NetID
+	npns.inUse = false
+	np.namespaces[netns.NetID] = npns
+
+	npns.gotNetNamespace = true
+	if npns.gotNamespace {
+		np.flushNSMatchCache()
+		np.refreshNetworkPolicies(refreshForNamespaces)
 	}
 }
 
@@ -189,16 +207,23 @@ func (np *networkPolicyPlugin) DeleteNetNamespace(netns *networkv1.NetNamespace)
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	if npns, exists := np.namespaces[netns.NetID]; exists {
-		np.flushNSMatchCache()
-		if npns.inUse {
-			npns.inUse = false
-			// We call syncNamespaceFlows() not syncNamespace() because it
-			// needs to happen before we forget about the namespace.
-			np.syncNamespaceFlows(npns)
-		}
-		delete(np.namespaces, netns.NetID)
+	npns, exists := np.namespaces[netns.NetID]
+	if !exists {
+		return
 	}
+
+	if npns.inUse {
+		npns.inUse = false
+		// We call syncNamespaceFlows() not syncNamespace() because it
+		// needs to happen before we forget about the namespace.
+		np.syncNamespaceFlows(npns)
+	}
+	delete(np.namespaces, netns.NetID)
+	npns.gotNetNamespace = false
+
+	// We don't need to call flushNSMatchCache or refreshNetworkPolicies here; if the
+	// VNID doesn't get reused then the stale cache entries/flows won't hurt anything,
+	// and if it does get reused then things will be cleaned up then.
 }
 
 func (np *networkPolicyPlugin) GetVNID(namespace string) (uint32, error) {
@@ -319,11 +344,9 @@ func (np *networkPolicyPlugin) selectNamespacesInternal(sel labels.Selector) map
 	namespaces, wasCached := np.nsMatchCache[cacheKey]
 	if !wasCached {
 		namespaces = make(map[string]uint32)
-		for vnid, ns := range np.namespaces {
-			if kns, exists := np.kNamespaces[ns.name]; exists {
-				if sel.Matches(labels.Set(kns.Labels)) {
-					namespaces[ns.name] = vnid
-				}
+		for vnid, npns := range np.namespaces {
+			if npns.gotNamespace && sel.Matches(labels.Set(npns.labels)) {
+				namespaces[npns.name] = vnid
 			}
 		}
 		np.nsMatchCache[cacheKey] = namespaces
@@ -620,9 +643,22 @@ func (np *networkPolicyPlugin) handleAddOrUpdateNamespace(obj, _ interface{}, ev
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	np.kNamespaces[ns.Name] = *ns
-	np.flushNSMatchCache()
-	np.refreshNetworkPolicies(refreshForNamespaces)
+	npns := np.namespacesByName[ns.Name]
+	if npns == nil {
+		npns = newNPNamespace(ns.Name)
+		np.namespacesByName[ns.Name] = npns
+	}
+
+	if npns.gotNamespace && reflect.DeepEqual(npns.labels, ns.Labels) {
+		return
+	}
+	npns.labels = ns.Labels
+
+	npns.gotNamespace = true
+	if npns.gotNetNamespace {
+		np.flushNSMatchCache()
+		np.refreshNetworkPolicies(refreshForNamespaces)
+	}
 }
 
 func (np *networkPolicyPlugin) handleDeleteNamespace(obj interface{}) {
@@ -632,9 +668,17 @@ func (np *networkPolicyPlugin) handleDeleteNamespace(obj interface{}) {
 	np.lock.Lock()
 	defer np.lock.Unlock()
 
-	delete(np.kNamespaces, ns.Name)
-	np.flushNSMatchCache()
-	np.refreshNetworkPolicies(refreshForNamespaces)
+	npns := np.namespacesByName[ns.Name]
+	if npns == nil {
+		return
+	}
+
+	delete(np.namespacesByName, ns.Name)
+	npns.gotNamespace = false
+
+	// We don't need to call flushNSMatchCache or refreshNetworkPolicies here; if the
+	// VNID doesn't get reused then the stale cache entries/flows won't hurt anything,
+	// and if it does get reused then things will be cleaned up then.
 }
 
 func (np *networkPolicyPlugin) refreshNetworkPolicies(refreshFor refreshForType) {

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -528,5 +529,164 @@ func TestNetworkPolicy(t *testing.T) {
 	})
 	if err != nil {
 		t.Error(err.Error())
+	}
+}
+
+// Disabled (by initial "_") becaues it's really really slow in CI for some reason?
+func _TestNetworkPolicyCache(t *testing.T) {
+	const (
+		initialNamespaces uint32 = 1000
+		extraNamespaces   uint32 = 500
+	)
+
+	np := &networkPolicyPlugin{
+		namespaces:       make(map[uint32]*npNamespace),
+		namespacesByName: make(map[string]*npNamespace),
+		pods:             make(map[ktypes.UID]corev1.Pod),
+		nsMatchCache:     make(map[string]*npCacheEntry),
+	}
+	np.vnids = newNodeVNIDMap(np, nil)
+
+	start := time.Now()
+
+	// Create initialNamespaces namespaces, each with deny-all, allow-from-self, and
+	// allow-from-global-namespace policies
+	for vnid := uint32(0); vnid < initialNamespaces; vnid++ {
+		name := fmt.Sprintf("namespace-%d", vnid)
+		addNamespace(np, name, vnid, map[string]string{
+			"pod.network.openshift.io/legacy-netid": fmt.Sprintf("%d", vnid),
+			"name":                                  name,
+		})
+		npns := np.namespaces[vnid]
+
+		np.handleAddOrUpdateNetworkPolicy(&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "deny-all",
+				UID:       uid(npns, "deny-all"),
+				Namespace: name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+			},
+		}, nil, watch.Added)
+
+		np.handleAddOrUpdateNetworkPolicy(&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-from-self",
+				UID:       uid(npns, "allow-from-self"),
+				Namespace: name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{
+					From: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{},
+					}},
+				}},
+			},
+		}, nil, watch.Added)
+
+		np.handleAddOrUpdateNetworkPolicy(&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-from-global-namespaces",
+				UID:       uid(npns, "allow-from-global-namespaces"),
+				Namespace: name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{
+					From: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"pod.network.openshift.io/legacy-netid": "0",
+							},
+						},
+					}},
+				}},
+			},
+		}, nil, watch.Added)
+	}
+
+	// Create an additional NetworkPolicy in namespace-1 for each namespace
+	// that comes after it, allowing access from only that one Namespace. (Ugh!)
+	npns1 := np.namespaces[1]
+	for vnid := uint32(2); vnid < initialNamespaces; vnid++ {
+		name := fmt.Sprintf("namespace-%d", vnid)
+		np.handleAddOrUpdateNetworkPolicy(&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-from-" + name,
+				UID:       uid(npns1, name),
+				Namespace: npns1.name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{
+					From: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"name": name,
+							},
+						},
+					}},
+				}},
+			},
+		}, nil, watch.Added)
+	}
+
+	// Re-add all the namespaces; this simulates what happens on sdn startup.
+	for vnid := uint32(0); vnid < initialNamespaces; vnid++ {
+		name := fmt.Sprintf("namespace-%d", vnid)
+		addNamespace(np, name, vnid, map[string]string{
+			"pod.network.openshift.io/legacy-netid": fmt.Sprintf("%d", vnid),
+			"name":                                  name,
+		})
+	}
+
+	// Add more namespaces...
+	for vnid := initialNamespaces; vnid < initialNamespaces+extraNamespaces; vnid++ {
+		name := fmt.Sprintf("namespace-%d", vnid)
+		addNamespace(np, name, vnid, map[string]string{
+			"pod.network.openshift.io/legacy-netid": fmt.Sprintf("%d", vnid),
+			"name":                                  name,
+		})
+	}
+
+	// On my laptop this runs in 4s with the cache and 1m45s without
+	elapsed := time.Since(start)
+	if elapsed > time.Minute {
+		t.Fatalf("Test took unexpectedly long (%v); cache is broken", elapsed)
+	}
+
+	// Deleting any namespace-selecting policy from any namespace will cause the cache
+	// to shrink
+	cacheSize := len(np.nsMatchCache)
+	npns2 := np.namespaces[2]
+	np.handleDeleteNetworkPolicy(&networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-from-global-namespaces",
+			UID:       uid(npns2, "allow-from-global-namespaces"),
+			Namespace: npns2.name,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pod.network.openshift.io/legacy-netid": "0",
+						},
+					},
+				}},
+			}},
+		},
+	})
+	if len(np.nsMatchCache) != cacheSize-1 {
+		t.Fatalf("Expected cache size to shrink from %d to %d, got %d", cacheSize, cacheSize-1, len(np.nsMatchCache))
 	}
 }

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -130,7 +130,7 @@ func TestNetworkPolicy(t *testing.T) {
 		namespaces:       make(map[uint32]*npNamespace),
 		namespacesByName: make(map[string]*npNamespace),
 		pods:             make(map[ktypes.UID]corev1.Pod),
-		nsMatchCache:     make(map[string]map[string]uint32),
+		nsMatchCache:     make(map[string]*npCacheEntry),
 	}
 	np.vnids = newNodeVNIDMap(np, nil)
 
@@ -467,6 +467,62 @@ func TestNetworkPolicy(t *testing.T) {
 				"reg0=4",
 				"reg0=6",
 				"reg0=8",
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// Deleting a policy in one namespace will not affect other namespaces
+	npns4 := np.namespaces[4]
+	np.handleDeleteNetworkPolicy(&networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-from-default",
+			UID:       uid(npns4, "allow-from-default"),
+			Namespace: npns4.name,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"default": "true",
+						},
+					},
+				}},
+			}},
+		},
+	})
+
+	err = assertPolicies(npns4, 2, map[string]*npPolicy{
+		"allow-from-self": {
+			watchesNamespaces: false,
+			watchesPods:       false,
+			flows: []string{
+				fmt.Sprintf("reg0=%d", npns4.vnid),
+			},
+		},
+		"allow-client-to-server": {
+			watchesNamespaces: false,
+			watchesPods:       true,
+			flows: []string{
+				fmt.Sprintf("ip, nw_dst=%s, reg0=%d, ip, nw_src=%s", serverIP(npns4), npns4.vnid, clientIP(npns4)),
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	err = assertPolicies(npns1, 5, map[string]*npPolicy{
+		"allow-from-default": {
+			watchesNamespaces: true,
+			watchesPods:       false,
+			flows: []string{
+				"reg0=0",
 			},
 		},
 	})

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -31,6 +31,21 @@ func addNamespace(np *networkPolicyPlugin, name string, vnid uint32, labels map[
 	}, nil, watch.Added)
 }
 
+func delNamespace(np *networkPolicyPlugin, name string, vnid uint32) {
+	np.vnids.handleDeleteNetNamespace(&networkv1.NetNamespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		NetName: name,
+		NetID:   vnid,
+	})
+	np.handleDeleteNamespace(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	})
+}
+
 func uid(npns *npNamespace, name string) ktypes.UID {
 	return ktypes.UID(name + "-" + npns.name)
 }
@@ -112,9 +127,10 @@ func addPods(np *networkPolicyPlugin, npns *npNamespace) {
 
 func TestNetworkPolicy(t *testing.T) {
 	np := &networkPolicyPlugin{
-		namespaces:  make(map[uint32]*npNamespace),
-		kNamespaces: make(map[string]corev1.Namespace),
-		pods:        make(map[ktypes.UID]corev1.Pod),
+		namespaces:       make(map[uint32]*npNamespace),
+		namespacesByName: make(map[string]*npNamespace),
+		pods:             make(map[ktypes.UID]corev1.Pod),
+		nsMatchCache:     make(map[string]map[string]uint32),
 	}
 	np.vnids = newNodeVNIDMap(np, nil)
 
@@ -421,5 +437,40 @@ func TestNetworkPolicy(t *testing.T) {
 		default:
 			t.Errorf("Unexpected namespace %d / %s", vnid, npns.name)
 		}
+	}
+
+	// If we delete a namespace, then stale policies may be left behind...
+	delNamespace(np, "namespace-2", 2)
+	err = assertPolicies(npns1, 5, map[string]*npPolicy{
+		"allow-from-even": {
+			watchesNamespaces: true,
+			watchesPods:       false,
+			flows: []string{
+				"reg0=2",
+				"reg0=4",
+				"reg0=6",
+				"reg0=8",
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// ...but they'll be cleaned up as soon as we add any new namespace
+	addNamespace(np, "unrelated", 100, nil)
+	err = assertPolicies(npns1, 5, map[string]*npPolicy{
+		"allow-from-even": {
+			watchesNamespaces: true,
+			watchesPods:       false,
+			flows: []string{
+				"reg0=4",
+				"reg0=6",
+				"reg0=8",
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
 	}
 }


### PR DESCRIPTION
The previous fix (#36) did not solve the customer problem because in addition to having thousands of identical copies of the "allow-from-global-namespace" policies (which the cache handles well), they also have thousands of single-namespace-to-single-namespace policies, which the cache didn't optimize as well, because we keep flushing the entire cache even though 99% of the matches didn't change. So this (specifically the second commit) tries to fix that by just making incremental updates to the cache when namespaces change, rather than destroying it every time. See the commit messages for more details
