### PR TITLE
Bug 1753216: Clean up egress IPs on startup

### DIFF
--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -14,6 +14,10 @@ type testEIPWatcher struct {
 	changes []string
 }
 
+func (w *testEIPWatcher) Synced() {
+	panic("should not be reached in unit test")
+}
+
 func (w *testEIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP string) {
 	w.changes = append(w.changes, fmt.Sprintf("claim %s on %s for namespace %d", egressIP, nodeIP, vnid))
 }

--- a/pkg/network/master/egressip.go
+++ b/pkg/network/master/egressip.go
@@ -190,6 +190,9 @@ func (eim *egressIPManager) check(retrying bool) bool {
 	return needRetry
 }
 
+func (eim *egressIPManager) Synced() {
+}
+
 func (eim *egressIPManager) ClaimEgressIP(vnid uint32, egressIP, nodeIP string) {
 }
 

--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -5,7 +5,6 @@ package node
 import (
 	"fmt"
 	"os/exec"
-	"sync"
 	"syscall"
 	"time"
 
@@ -19,7 +18,7 @@ import (
 )
 
 type egressIPWatcher struct {
-	sync.Mutex
+	// We don't need a mutex because tracker serializes all of its callbacks to us
 
 	tracker *common.EgressIPTracker
 
@@ -59,6 +58,45 @@ func (eip *egressIPWatcher) Start(networkInformers networkinformers.SharedInform
 
 	eip.tracker.Start(networkInformers.Network().V1().HostSubnets(), networkInformers.Network().V1().NetNamespaces())
 	return nil
+}
+
+func (eip *egressIPWatcher) Synced() {
+	link, _, err := GetLinkDetails(eip.localIP)
+	if err != nil {
+		// shouldn't happen, but obviously there's nothing to clean up...
+		return
+	}
+	label, err := egressIPLabel(link)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Could not check for stale egress IPs: %v", err))
+		return
+	}
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Could not check for stale egress IPs: %v", err))
+		return
+	}
+
+	for _, addr := range addrs {
+		ip := addr.IP.String()
+		if addr.Label == label && eip.iptablesMark[ip] == "" {
+			klog.Infof("Cleaning up stale egress IP %s", addr.IP.String())
+			err = netlink.AddrDel(link, &addr)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("Could not clean up stale egress IP: %v", err))
+			}
+		}
+	}
+}
+
+func egressIPLabel(link netlink.Link) (string, error) {
+	// An address label must start with the link name plus ":", and must be at most 15
+	// characters long. If the link name is too long then we can't label egress IPs.
+	label := link.Attrs().Name + ":eip"
+	if len(label) > 15 {
+		return "", fmt.Errorf("link name %q is too long", link.Attrs().Name)
+	}
+	return label, nil
 }
 
 // Convert vnid to a hex value that is not 0, does not have masqueradeBit set, and isn't
@@ -143,6 +181,7 @@ func (eip *egressIPWatcher) assignEgressIP(egressIP, mark string) error {
 	if !localEgressNet.Contains(addr.IP) {
 		return fmt.Errorf("egress IP %q is not in local network %s of interface %s", egressIP, localEgressNet.String(), localEgressLink.Attrs().Name)
 	}
+	addr.Label, _ = egressIPLabel(localEgressLink)
 	err = netlink.AddrAdd(localEgressLink, addr)
 	if err != nil {
 		if err == syscall.EEXIST {


### PR DESCRIPTION
If a node lost an egress IP while the sdn process was being restarted, the sdn wouldn't remove the stale egress IP from the node's interface, so you'd end up with two nodes fighting over the packets.

This fixes that by (1) labeling the egress IPs we add so that we can recognize them later, and (2) running a cleanup after we've finished syncing with the master on startup.

(Also, `node.egressIPWatcher` had a mutex that it wasn't using... but it turns out that this isn't a problem because its methods are only called from `common.EgressIPTracker`, which *does* use a mutex when calling the watcher methods. I probably meant to delete the mutex when I split out the `common` parts of the egress IP code, but forgot.)