### PR TITLE
Bug 1768436: UPSTREAM: 74840: kube-proxy: Drop packets in INVALID state

### DIFF
--- a/glide.diff
+++ b/glide.diff
@@ -3,3 +3,19 @@ diff --no-dereference -N -r current/vendor/github.com/vishvananda/netlink/link_l
 < 			gre.FlowBased = true
 ---
 > 			gre.FlowBased = int8(datum.Value[0]) != 0
+diff --no-dereference -N -r current/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go updated/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
+37c37
+< 	v1 "k8s.io/api/core/v1"
+---
+> 	"k8s.io/api/core/v1"
+1316,1325d1315
+< 
+< 	// Drop the packets in INVALID state, which would potentially cause
+< 	// unexpected connection reset.
+< 	// https://github.com/kubernetes/kubernetes/issues/74839
+< 	writeLine(proxier.filterRules,
+< 		"-A", string(kubeForwardChain),
+< 		"-m", "conntrack",
+< 		"--ctstate", "INVALID",
+< 		"-j", "DROP",
+< 	)

--- a/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
@@ -34,7 +34,7 @@ import (
 
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1313,6 +1313,16 @@ func (proxier *Proxier) syncProxyRules() {
 			writeLine(proxier.natRules, args...)
 		}
 	}
+
+	// Drop the packets in INVALID state, which would potentially cause
+	// unexpected connection reset.
+	// https://github.com/kubernetes/kubernetes/issues/74839
+	writeLine(proxier.filterRules,
+		"-A", string(kubeForwardChain),
+		"-m", "conntrack",
+		"--ctstate", "INVALID",
+		"-j", "DROP",
+	)
 
 	// If the masqueradeMark has been added then we want to forward that same
 	// traffic, this allows NodePort traffic to be forwarded even if the default


### PR DESCRIPTION
I initially tried to file this as https://github.com/openshift/kubernetes/pull/89 but that's failing CI for infrastructural reasons.

With openshift/origin, they mostly don't modify openshift/kubernetes itself after the initial creation of a new branch, and I think the repo isn't really set up to deal with us wanting to do that. (eg, the branches are protected but the OWNERS files aren't changed from upstream. And CI seems to be broken.). So maybe we should shift to having a clean(er) openshift/kubernetes branch and keeping (at least some) divergences here instead of there?

/cc @dcbw @squeed 