### PR TITLE
UPSTREAM 83911: Fix DeltaFIFO Replace method

### DIFF
--- a/glide.diff
+++ b/glide.diff
@@ -3,3 +3,49 @@ diff --no-dereference -N -r current/vendor/github.com/vishvananda/netlink/link_l
 < 			gre.FlowBased = true
 ---
 > 			gre.FlowBased = int8(datum.Value[0]) != 0
+diff --no-dereference -N -r current/vendor/k8s.io/client-go/tools/cache/delta_fifo.go updated/vendor/k8s.io/client-go/tools/cache/delta_fifo.go
+297a298,304
+> // willObjectBeDeletedLocked returns true only if the last delta for the
+> // given object is Delete. Caller must lock first.
+> func (f *DeltaFIFO) willObjectBeDeletedLocked(id string) bool {
+> 	deltas := f.items[id]
+> 	return len(deltas) > 0 && deltas[len(deltas)-1].Type == Deleted
+> }
+> 
+303a311,317
+> 	}
+> 
+> 	// If object is supposed to be deleted (last event is Deleted),
+> 	// then we should ignore Sync events, because it would result in
+> 	// recreation of this object.
+> 	if actionType == Sync && f.willObjectBeDeletedLocked(id) {
+> 		return nil
+diff --no-dereference -N -r current/vendor/k8s.io/client-go/tools/cache/delta_fifo_test.go updated/vendor/k8s.io/client-go/tools/cache/delta_fifo_test.go
+88,114d87
+< // TestDeltaFIFO_replaceWithDeleteDeltaIn tests that a `Sync` delta for an
+< // object `O` with ID `X` is added when .Replace is called and `O` is among the
+< // replacement objects even if the DeltaFIFO already stores in terminal position
+< // a delta of type `Delete` for ID `X`. Not adding the `Sync` delta causes
+< // SharedIndexInformers to miss `O`'s create notification, see https://github.com/kubernetes/kubernetes/issues/83810
+< // for more details.
+< func TestDeltaFIFO_replaceWithDeleteDeltaIn(t *testing.T) {
+< 	oldObj := mkFifoObj("foo", 1)
+< 	newObj := mkFifoObj("foo", 2)
+< 
+< 	f := NewDeltaFIFO(testFifoObjectKeyFunc, keyLookupFunc(func() []testFifoObject {
+< 		return []testFifoObject{oldObj}
+< 	}))
+< 
+< 	f.Delete(oldObj)
+< 	f.Replace([]interface{}{newObj}, "")
+< 
+< 	actualDeltas := Pop(f)
+< 	expectedDeltas := Deltas{
+< 		Delta{Type: Deleted, Object: oldObj},
+< 		Delta{Type: Sync, Object: newObj},
+< 	}
+< 	if !reflect.DeepEqual(expectedDeltas, actualDeltas) {
+< 		t.Errorf("expected %#v, got %#v", expectedDeltas, actualDeltas)
+< 	}
+< }
+< 

--- a/vendor/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/vendor/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -295,26 +295,12 @@ func isDeletionDup(a, b *Delta) *Delta {
 	return b
 }
 
-// willObjectBeDeletedLocked returns true only if the last delta for the
-// given object is Delete. Caller must lock first.
-func (f *DeltaFIFO) willObjectBeDeletedLocked(id string) bool {
-	deltas := f.items[id]
-	return len(deltas) > 0 && deltas[len(deltas)-1].Type == Deleted
-}
-
 // queueActionLocked appends to the delta list for the object.
 // Caller must lock first.
 func (f *DeltaFIFO) queueActionLocked(actionType DeltaType, obj interface{}) error {
 	id, err := f.KeyOf(obj)
 	if err != nil {
 		return KeyError{obj, err}
-	}
-
-	// If object is supposed to be deleted (last event is Deleted),
-	// then we should ignore Sync events, because it would result in
-	// recreation of this object.
-	if actionType == Sync && f.willObjectBeDeletedLocked(id) {
-		return nil
 	}
 
 	newDeltas := append(f.items[id], Delta{actionType, obj})


### PR DESCRIPTION
Fix DeltaFIFO Replace method to prevent SharedIndexInformers from
missing notifications.