### PR TITLE
Add IPv6 support and multiple CIDR support to SubnetAllocator

### DIFF
--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -38,9 +38,7 @@ type OsdnMaster struct {
 	netNamespaceInformer networkinformers.NetNamespaceInformer
 
 	// Used for allocating subnets in order
-	subnetAllocatorList []*SubnetAllocator
-	// Used for clusterNetwork --> subnetAllocator lookup
-	subnetAllocatorMap map[common.ParsedClusterNetworkEntry]*SubnetAllocator
+	subnetAllocator *SubnetAllocator
 
 	// Holds Node IP used in creating host subnet for a node
 	hostSubnetNodeIPs map[ktypes.UID]string
@@ -66,8 +64,7 @@ func Start(networkClient networkclient.Interface, kClient kclientset.Interface,
 		hostSubnetInformer:   networkInformers.Network().V1().HostSubnets(),
 		netNamespaceInformer: networkInformers.Network().V1().NetNamespaces(),
 
-		subnetAllocatorMap: map[common.ParsedClusterNetworkEntry]*SubnetAllocator{},
-		hostSubnetNodeIPs:  map[ktypes.UID]string{},
+		hostSubnetNodeIPs: map[ktypes.UID]string{},
 	}
 
 	if err = master.checkClusterNetworkAgainstLocalNetworks(); err != nil {

--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -20,6 +20,7 @@ import (
 	networkinformers "github.com/openshift/client-go/network/informers/externalversions/network/v1"
 	"github.com/openshift/library-go/pkg/network/networkutils"
 	"github.com/openshift/sdn/pkg/network/common"
+	masterutil "github.com/openshift/sdn/pkg/network/master/util"
 )
 
 const (
@@ -38,7 +39,7 @@ type OsdnMaster struct {
 	netNamespaceInformer networkinformers.NetNamespaceInformer
 
 	// Used for allocating subnets in order
-	subnetAllocator *SubnetAllocator
+	subnetAllocator *masterutil.SubnetAllocator
 
 	// Holds Node IP used in creating host subnet for a node
 	hostSubnetNodeIPs map[ktypes.UID]string

--- a/pkg/network/master/subnet_allocator_test.go
+++ b/pkg/network/master/subnet_allocator_test.go
@@ -6,6 +6,12 @@ import (
 	"testing"
 )
 
+func newSubnetAllocator(clusterCIDR string, hostBits uint32) (*SubnetAllocator, error) {
+	sna := NewSubnetAllocator()
+	err := sna.AddNetworkRange(clusterCIDR, hostBits)
+	return sna, err
+}
+
 func networkID(n int) string {
 	if n == -1 {
 		return "network"
@@ -15,19 +21,21 @@ func networkID(n int) string {
 }
 
 func allocateExpected(sna *SubnetAllocator, n int, expected string) error {
-	sn, err := sna.allocateNetwork()
+	sn, err := sna.AllocateNetwork()
 	if err != nil {
 		return fmt.Errorf("failed to allocate %s (%s): %v", networkID(n), expected, err)
 	}
-	if sn.String() != expected {
-		return fmt.Errorf("failed to allocate %s: expected %s, got %s", networkID(n), expected, sn.String())
+	if sn != expected {
+		return fmt.Errorf("failed to allocate %s: expected %s, got %s", networkID(n), expected, sn)
 	}
 	return nil
 }
 
 func allocateNotExpected(sna *SubnetAllocator, n int) error {
-	if sn, err := sna.allocateNetwork(); err == nil {
-		return fmt.Errorf("unexpectedly succeeded in allocating %s (sn=%s)", networkID(n), sn.String())
+	if sn, err := sna.AllocateNetwork(); err == nil {
+		return fmt.Errorf("unexpectedly succeeded in allocating %s (sn=%s)", networkID(n), sn)
+	} else if err != ErrSubnetAllocatorFull {
+		return fmt.Errorf("returned error was not ErrSubnetAllocatorFull (%v)", err)
 	}
 	return nil
 }
@@ -89,7 +97,7 @@ func TestAllocateSubnetLargeSubnetBits(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sna.next = 1023
+	sna.ranges[0].next = 1023
 	if err = allocateExpected(sna, -1, "10.1.255.192/26"); err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +128,7 @@ func TestAllocateSubnetOverlapping(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sna.next = 255
+	sna.ranges[0].next = 255
 	if err := allocateExpected(sna, -1, "10.3.252.0/22"); err != nil {
 		t.Fatal(err)
 	}
@@ -167,36 +175,32 @@ func TestMarkAllocatedNetwork(t *testing.T) {
 		t.Fatal("Failed to initialize IP allocator: ", err)
 	}
 
-	allocSubnets := make([]*net.IPNet, 4)
+	allocSubnets := make([]string, 4)
 	for i := 0; i < 4; i++ {
-		if allocSubnets[i], err = sna.allocateNetwork(); err != nil {
+		if allocSubnets[i], err = sna.AllocateNetwork(); err != nil {
 			t.Fatal("Failed to allocate network: ", err)
 		}
 	}
 
-	if sn, err := sna.allocateNetwork(); err == nil {
-		t.Fatalf("Unexpectedly succeeded in allocating network (sn=%s)", sn.String())
+	if sn, err := sna.AllocateNetwork(); err == nil {
+		t.Fatalf("Unexpectedly succeeded in allocating network (sn=%s)", sn)
 	}
-	if err := sna.releaseNetwork(allocSubnets[2]); err != nil {
-		t.Fatalf("Failed to release the subnet (allocSubnets[2]=%s): %v", allocSubnets[2].String(), err)
+	if err := sna.ReleaseNetwork(allocSubnets[2]); err != nil {
+		t.Fatalf("Failed to release the subnet (allocSubnets[2]=%s): %v", allocSubnets[2], err)
 	}
 	for i := 0; i < 2; i++ {
-		if err := sna.markAllocatedNetwork(allocSubnets[2]); err != nil {
-			t.Fatalf("Failed to mark allocated subnet (allocSubnets[2]=%s): %v", allocSubnets[2].String(), err)
+		if err := sna.MarkAllocatedNetwork(allocSubnets[2]); err != nil {
+			t.Fatalf("Failed to mark allocated subnet (allocSubnets[2]=%s): %v", allocSubnets[2], err)
 		}
 	}
-	if sn, err := sna.allocateNetwork(); err == nil {
-		t.Fatalf("Unexpectedly succeeded in allocating network (sn=%s)", sn.String())
+	if sn, err := sna.AllocateNetwork(); err == nil {
+		t.Fatalf("Unexpectedly succeeded in allocating network (sn=%s)", sn)
 	}
 
 	// Test subnet that does not belong to network
-	var sn *net.IPNet
-	_, sn, err = net.ParseCIDR("10.2.3.4/24")
-	if err != nil {
-		t.Fatal("Failed to parse given network: ", err)
-	}
-	if err := sna.markAllocatedNetwork(sn); err == nil {
-		t.Fatalf("Unexpectedly succeeded in marking allocated subnet that doesn't belong to network (sn=%s)", sn.String())
+	sn := "10.2.3.4/24"
+	if err := sna.MarkAllocatedNetwork(sn); err == nil {
+		t.Fatalf("Unexpectedly succeeded in marking allocated subnet that doesn't belong to network (sn=%s)", sn)
 	}
 }
 
@@ -206,41 +210,86 @@ func TestAllocateReleaseSubnet(t *testing.T) {
 		t.Fatal("Failed to initialize IP allocator: ", err)
 	}
 
-	var releaseSn *net.IPNet
+	var releaseSn string
 
 	for i := 0; i < 4; i++ {
-		sn, err := sna.allocateNetwork()
+		sn, err := sna.AllocateNetwork()
 		if err != nil {
 			t.Fatal("Failed to allocate network: ", err)
 		}
-		if sn.String() != fmt.Sprintf("10.1.%d.0/18", i*64) {
-			t.Fatalf("Did not get expected subnet (i=%d, sn=%s)", i, sn.String())
+		if sn != fmt.Sprintf("10.1.%d.0/18", i*64) {
+			t.Fatalf("Did not get expected subnet (i=%d, sn=%s)", i, sn)
 		}
 		if i == 2 {
 			releaseSn = sn
 		}
 	}
 
-	sn, err := sna.allocateNetwork()
+	sn, err := sna.AllocateNetwork()
 	if err == nil {
-		t.Fatalf("Unexpectedly succeeded in allocating network (sn=%s)", sn.String())
+		t.Fatalf("Unexpectedly succeeded in allocating network (sn=%s)", sn)
 	}
 
-	if err := sna.releaseNetwork(releaseSn); err != nil {
-		t.Fatalf("Failed to release the subnet (releaseSn=%s): %v", releaseSn.String(), err)
+	if err := sna.ReleaseNetwork(releaseSn); err != nil {
+		t.Fatalf("Failed to release the subnet (releaseSn=%s): %v", releaseSn, err)
 	}
 
-	sn, err = sna.allocateNetwork()
+	sn, err = sna.AllocateNetwork()
 	if err != nil {
 		t.Fatal("Failed to allocate network: ", err)
 	}
-	if sn.String() != releaseSn.String() {
-		t.Fatalf("Did not get expected subnet (sn=%s)", sn.String())
+	if sn != releaseSn {
+		t.Fatalf("Did not get expected subnet (sn=%s)", sn)
 	}
 
-	sn, err = sna.allocateNetwork()
+	sn, err = sna.AllocateNetwork()
 	if err == nil {
-		t.Fatalf("Unexpectedly succeeded in allocating network (sn=%s)", sn.String())
+		t.Fatalf("Unexpectedly succeeded in allocating network (sn=%s)", sn)
+	}
+}
+
+func TestMultipleSubnets(t *testing.T) {
+	sna, err := newSubnetAllocator("10.1.0.0/16", 14)
+	if err != nil {
+		t.Fatal("Failed to initialize IP allocator: ", err)
+	}
+	err = sna.AddNetworkRange("10.2.0.0/16", 14)
+	if err != nil {
+		t.Fatal("Failed to add network range: ", err)
+	}
+
+	for i := 0; i < 4; i++ {
+		if err := allocateExpected(sna, i, fmt.Sprintf("10.1.%d.0/18", i*64)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for i := 0; i < 4; i++ {
+		if err := allocateExpected(sna, i+4, fmt.Sprintf("10.2.%d.0/18", i*64)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := allocateNotExpected(sna, 8); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sna.ReleaseNetwork("10.1.128.0/18"); err != nil {
+		t.Fatalf("Failed to release the subnet 10.1.128.0/18: %v", err)
+	}
+	if err := sna.ReleaseNetwork("10.2.128.0/18"); err != nil {
+		t.Fatalf("Failed to release the subnet 10.2.128.0/18: %v", err)
+	}
+
+	if err := allocateExpected(sna, -1, "10.1.128.0/18"); err != nil {
+		t.Fatal(err)
+	}
+	if err := allocateExpected(sna, -1, "10.2.128.0/18"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := allocateNotExpected(sna, -1); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/network/master/subnets.go
+++ b/pkg/network/master/subnets.go
@@ -16,10 +16,11 @@ import (
 	networkapi "github.com/openshift/api/network/v1"
 	"github.com/openshift/sdn/pkg/network"
 	"github.com/openshift/sdn/pkg/network/common"
+	masterutil "github.com/openshift/sdn/pkg/network/master/util"
 )
 
 func (master *OsdnMaster) startSubnetMaster() error {
-	master.subnetAllocator = NewSubnetAllocator()
+	master.subnetAllocator = masterutil.NewSubnetAllocator()
 	for _, cn := range master.networkInfo.ClusterNetworks {
 		err := master.subnetAllocator.AddNetworkRange(cn.ClusterCIDR.String(), cn.HostSubnetLength)
 		if err != nil {

--- a/pkg/network/master/util/subnet_allocator.go
+++ b/pkg/network/master/util/subnet_allocator.go
@@ -1,4 +1,4 @@
-package master
+package util
 
 import (
 	"fmt"

--- a/pkg/network/master/util/subnet_allocator_test.go
+++ b/pkg/network/master/util/subnet_allocator_test.go
@@ -1,4 +1,4 @@
-package master
+package util
 
 import (
 	"fmt"


### PR DESCRIPTION
This extends SubnetAllocator to support IPv6 ClusterNetworkCIDRs, and then also moves the code from OsdnMaster for handling multiple subnets and makes it part of SubnetAllocator instead.

(Of course, with stock OCP you can't configure an IPv6 ClusterNetwork so this should have no effect on end users at this point, and thus doesn't count as a feature, and would be exempt on IPv6 grounds even if it did.)

ovn-kubernetes currently vendors an older copy of SubnetAllocator (via `"github.com/openshift/origin/pkg/util/netutils"`) and then independently reimplements the multiple CIDR stuff on top of that. My intention was that it could be updated to either copy+paste or vendor this version instead, to provide IPv6 support there as well (and to remove the duplicated multiple CIDR code).