### PR TITLE
Simplify CNI plugin build, copy updated rules to images/sdn/

### DIFF
--- a/images/node/Dockerfile.rhel
+++ b/images/node/Dockerfile.rhel
@@ -1,16 +1,12 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/sdn
 COPY . .
-RUN CGO_ENABLED=1 make build --warn-undefined-variables
-
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder_cni
-WORKDIR /go/src/github.com/openshift/sdn
-COPY . .
-RUN CGO_ENABLED=0 GO_BUILD_FLAGS="-tags no_openssl" make build --warn-undefined-variables
+RUN make build --warn-undefined-variables
+RUN CGO_ENABLED=0 GO_BUILD_FLAGS="-tags no_openssl" make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/sdn-cni-plugin" --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/
-COPY --from=builder_cni /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/openshift-sdn
+COPY --from=builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/openshift-sdn
 
 RUN INSTALL_PKGS=" \
       openvswitch2.11 container-selinux socat ethtool nmap-ncat \

--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -1,7 +1,8 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/sdn
 COPY . .
-RUN CGO_ENABLED=0 make build --warn-undefined-variables
+RUN make build --warn-undefined-variables
+RUN CGO_ENABLED=0 GO_BUILD_FLAGS="-tags no_openssl" make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/sdn-cni-plugin" --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/openshift-sdn-node


### PR DESCRIPTION
#62 changed the rules for building the CNI plugin, but it was more complicated than it needed to be, and also it only modified the soon-to-be-removed `images/node/Dockerfile.rhel` and not the new `images/sdn/Dockerfile.rhel` (re #59)

/cc @knobunc @lsm5 
