### PR TITLE
Bug 1780387: host-local plugin should be built and executed within container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /sdn-cni-plugin
 /network-controller
 /kube-proxy
+/host-local
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all: build
 
 GO_BUILD_PACKAGES = \
     ./cmd/... \
+    ./vendor/github.com/containernetworking/plugins/plugins/ipam/host-local \
     ./vendor/k8s.io/kubernetes/cmd/kube-proxy
 
 # Include the library makefile

--- a/images/node/Dockerfile.rhel
+++ b/images/node/Dockerfile.rhel
@@ -7,6 +7,7 @@ RUN CGO_ENABLED=0 GO_BUILD_FLAGS="-tags no_openssl" make build GO_BUILD_PACKAGES
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/openshift-sdn
+COPY --from=builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
 
 RUN INSTALL_PKGS=" \
       openvswitch2.11 container-selinux socat ethtool nmap-ncat \

--- a/images/sdn/Dockerfile.fedora
+++ b/images/sdn/Dockerfile.fedora
@@ -9,6 +9,7 @@ FROM fedora:30
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/openshift-sdn-node
 COPY --from=builder /go/src/github.com/openshift/sdn/network-controller /usr/bin/openshift-sdn-controller
 COPY --from=builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/openshift-sdn
+COPY --from=builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
 
 RUN INSTALL_PKGS=" \
       openvswitch container-selinux socat ethtool nmap-ncat \

--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -8,6 +8,7 @@ FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/openshift-sdn-node
 COPY --from=builder /go/src/github.com/openshift/sdn/network-controller /usr/bin/openshift-sdn-controller
 COPY --from=builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/openshift-sdn
+COPY --from=builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
 
 RUN INSTALL_PKGS=" \
       openvswitch2.11 container-selinux socat ethtool nmap-ncat \

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -33,9 +33,9 @@ import (
 )
 
 const (
-	podInterfaceName = "eth0"
-	hostLocalDataDir = "/var/lib/cni/networks"
-	cniPluginsBinDir = "/host/opt/cni/bin"
+	podInterfaceName               = "eth0"
+	hostLocalDataDir               = "/var/lib/cni/networks"
+	containerLocalCniPluginsBinDir = "/usr/bin/cni"
 )
 
 type podHandler interface {
@@ -377,7 +377,7 @@ func createIPAMArgs(netnsPath string, action cniserver.CNICommand, id string) *i
 		ContainerID: id,
 		NetNS:       netnsPath,
 		IfName:      podInterfaceName,
-		Path:        cniPluginsBinDir,
+		Path:        containerLocalCniPluginsBinDir,
 	}
 }
 
@@ -388,7 +388,7 @@ func (m *podManager) ipamAdd(netnsPath string, id string) (*current.Result, net.
 	}
 
 	args := createIPAMArgs(netnsPath, cniserver.CNI_ADD, id)
-	r, err := invoke.ExecPluginWithResult(cniPluginsBinDir+"/host-local", m.ipamConfig, args)
+	r, err := invoke.ExecPluginWithResult(containerLocalCniPluginsBinDir+"/osdn-host-local", m.ipamConfig, args)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to run CNI IPAM ADD: %v", err)
 	}
@@ -408,7 +408,7 @@ func (m *podManager) ipamAdd(netnsPath string, id string) (*current.Result, net.
 // Run CNI IPAM release for the container
 func (m *podManager) ipamDel(id string) error {
 	args := createIPAMArgs("", cniserver.CNI_DEL, id)
-	err := invoke.ExecPluginWithoutResult(cniPluginsBinDir+"/host-local", m.ipamConfig, args)
+	err := invoke.ExecPluginWithoutResult(containerLocalCniPluginsBinDir+"/osdn-host-local", m.ipamConfig, args)
 	if err != nil {
 		return fmt.Errorf("failed to run CNI IPAM DEL: %v", err)
 	}


### PR DESCRIPTION
Due to issues with the host-local plugin coredumping, host-local should be built
in the sdn build process and executed from within the container instead of on the host.

Originally removed in commit: 6d6d35f2f51c84c86b32723e88661c3cd8e379a0

In reference to BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1780387

@squeed recommended naming the binary to `osdn-host-local` to differentiate it. I also went and put it in a directory named `/opt/cni/container-bin` to differentiate it from the host's `/opt/cni/bin` however, I certainly would like any feedback on that naming.