### PR TITLE
Bug 1787488: Clean up stale egress IP iptables rules on startup

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -87,6 +87,8 @@ func (eip *egressIPWatcher) Synced() {
 			}
 		}
 	}
+
+	eip.iptables.SyncEgressIPRules()
 }
 
 func egressIPLabel(link netlink.Link) (string, error) {


### PR DESCRIPTION
Followup to #51; we were removing the stale egress IPs themselves but not the iptables rules associated with them.

I thought about putting the egress IP rules into a separate chain so that we could just flush the chain and then recreate it, which would have been a lot simpler, but then we'd also end up potentially dropping packets on restart, which we've tried to avoid. So I went with this approach.

I was going to add a unit test, but the fake iptables implementation isn't functional enough for this to work. Though... I guess I could use the real iptables implemntation and the fake exec... Anyway, it *does* work.