### PR TITLE
Bug 1762580: Add OPENSHIFT-PREROUTING chain

### DIFF
--- a/pkg/openshift-sdn/cmd.go
+++ b/pkg/openshift-sdn/cmd.go
@@ -170,6 +170,11 @@ func (sdn *OpenShiftSDN) Start(stopCh <-chan struct{}) error {
 
 	klog.V(2).Infof("openshift-sdn network plugin waiting for proxy startup to complete")
 	<-proxyInitChan
+	klog.V(2).Infof("openshift-sdn proxy startup complete")
+	err = sdn.finishInit()
+	if err != nil {
+		return err
+	}
 	klog.V(2).Infof("openshift-sdn network plugin registering startup")
 	if err := sdn.writeConfigFile(); err != nil {
 		klog.Fatal(err)

--- a/pkg/openshift-sdn/sdn.go
+++ b/pkg/openshift-sdn/sdn.go
@@ -39,6 +39,12 @@ func (sdn *OpenShiftSDN) runSDN() error {
 	return sdn.OsdnNode.Start()
 }
 
+// finishInit runs the steps of the sdn that must be done after kube-proxy
+// is initialized
+func (sdn *OpenShiftSDN) finishInit() error {
+	return sdn.OsdnNode.FinishInit()
+}
+
 func (sdn *OpenShiftSDN) writeConfigFile() error {
 	// Make an event that openshift-sdn started
 	sdn.sdnRecorder.Eventf(&kclientv1.ObjectReference{Kind: "Node", Name: sdn.nodeName}, kclientv1.EventTypeNormal, "Starting", "openshift-sdn done initializing node networking.")


### PR DESCRIPTION
Fixes BZ#1762580. When using egressIP the packets going to
externalIP services are matched by KUBE-SERVICES rules, this means
the packets destination IP is modified to the endpoint IP address.

By adding this chain and a few rules on it, we guarantee the
packets marked for egressIP will skip the KUBE-SERVICES chains,
hence, the traffic to externalIP is sent to the externalIP rather
than an endpoint.