### PR TITLE
Bug 1804178: Revert excessive proxy logging

### DIFF
--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -365,7 +365,7 @@ func (proxy *OsdnProxy) OnEndpointsSynced() {
 }
 
 func (proxy *OsdnProxy) OnServiceAdd(service *corev1.Service) {
-	klog.V(2).Infof("sdn proxy: add svc %s/%s: %v", service.Namespace, service.Name, service)
+	klog.V(4).Infof("sdn proxy: add svc %s/%s: %v", service.Namespace, service.Name, service)
 	proxy.baseProxy.OnServiceAdd(service)
 }
 

--- a/pkg/network/proxyimpl/hybrid/proxy.go
+++ b/pkg/network/proxyimpl/hybrid/proxy.go
@@ -331,13 +331,12 @@ func (p *HybridProxier) Sync() {
 // We do this so that we can guarantee that changes are applied to both
 // proxies, especially when unidling a newly-awoken service.
 func (p *HybridProxier) syncProxyRules() {
-	klog.V(2).Infof("hybrid proxy: syncProxyRules start")
+	klog.V(4).Infof("hybrid proxy: syncProxyRules start")
 
 	p.mainProxy.SyncProxyRules()
-	klog.V(2).Infof("hybrid proxy: mainProxy.syncProxyRules complete")
 	p.unidlingProxy.SyncProxyRules()
 
-	klog.V(2).Infof("hybrid proxy: unidlingProxy.syncProxyRules complete")
+	klog.V(4).Infof("hybrid proxy: syncProxyRules finished")
 }
 
 // SyncLoop runs periodic work.  This is expected to run as a goroutine or as the main loop of the app.  It does not return.


### PR DESCRIPTION
The missing-proxy-updates problem has been fixed; we don't need to log so much.