### PR TITLE
Bug 1811739: Fix kube_proxy metrics

### DIFF
--- a/pkg/network/node/metrics.go
+++ b/pkg/network/node/metrics.go
@@ -12,11 +12,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/openshift/sdn/pkg/network/node/ovs"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 const (
@@ -36,8 +36,8 @@ const (
 )
 
 var (
-	OVSFlows = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	OVSFlows = metrics.NewGauge(
+		&metrics.GaugeOpts{
 			Namespace: SDNNamespace,
 			Subsystem: SDNSubsystem,
 			Name:      OVSFlowsKey,
@@ -45,8 +45,8 @@ var (
 		},
 	)
 
-	ARPCacheAvailableEntries = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	ARPCacheAvailableEntries = metrics.NewGauge(
+		&metrics.GaugeOpts{
 			Namespace: SDNNamespace,
 			Subsystem: SDNSubsystem,
 			Name:      ARPCacheAvailableEntriesKey,
@@ -54,8 +54,8 @@ var (
 		},
 	)
 
-	PodIPs = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	PodIPs = metrics.NewGauge(
+		&metrics.GaugeOpts{
 			Namespace: SDNNamespace,
 			Subsystem: SDNSubsystem,
 			Name:      PodIPsKey,
@@ -63,8 +63,8 @@ var (
 		},
 	)
 
-	PodOperationsErrors = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	PodOperationsErrors = metrics.NewCounterVec(
+		&metrics.CounterOpts{
 			Namespace: SDNNamespace,
 			Subsystem: SDNSubsystem,
 			Name:      PodOperationsErrorsKey,
@@ -73,8 +73,8 @@ var (
 		[]string{"operation_type"},
 	)
 
-	PodOperationsLatency = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	PodOperationsLatency = metrics.NewSummaryVec(
+		&metrics.SummaryOpts{
 			Namespace: SDNNamespace,
 			Subsystem: SDNSubsystem,
 			Name:      PodOperationsLatencyKey,
@@ -83,8 +83,8 @@ var (
 		[]string{"operation_type"},
 	)
 
-	VnidNotFoundErrors = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	VnidNotFoundErrors = metrics.NewCounter(
+		&metrics.CounterOpts{
 			Namespace: SDNNamespace,
 			Subsystem: SDNSubsystem,
 			Name:      VnidNotFoundErrorsKey,
@@ -105,12 +105,12 @@ var registerMetrics sync.Once
 // Register all node metrics.
 func RegisterMetrics() {
 	registerMetrics.Do(func() {
-		prometheus.MustRegister(OVSFlows)
-		prometheus.MustRegister(ARPCacheAvailableEntries)
-		prometheus.MustRegister(PodIPs)
-		prometheus.MustRegister(PodOperationsErrors)
-		prometheus.MustRegister(PodOperationsLatency)
-		prometheus.MustRegister(VnidNotFoundErrors)
+		legacyregistry.MustRegister(OVSFlows)
+		legacyregistry.MustRegister(ARPCacheAvailableEntries)
+		legacyregistry.MustRegister(PodIPs)
+		legacyregistry.MustRegister(PodOperationsErrors)
+		legacyregistry.MustRegister(PodOperationsLatency)
+		legacyregistry.MustRegister(VnidNotFoundErrors)
 	})
 }
 

--- a/pkg/openshift-sdn/proxy.go
+++ b/pkg/openshift-sdn/proxy.go
@@ -32,7 +32,7 @@ import (
 	sdnproxy "github.com/openshift/sdn/pkg/network/proxy"
 	"github.com/openshift/sdn/pkg/network/proxyimpl/hybrid"
 	"github.com/openshift/sdn/pkg/network/proxyimpl/unidler"
-	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog"
 )
 
@@ -217,7 +217,7 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		mux.HandleFunc("/proxyMode", func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "%s", sdn.ProxyConfig.Mode)
 		})
-		mux.Handle("/metrics", prometheus.Handler())
+		mux.Handle("/metrics", legacyregistry.Handler())
 		go utilwait.Until(func() {
 			err := http.ListenAndServe(sdn.ProxyConfig.MetricsBindAddress, mux)
 			if err != nil {


### PR DESCRIPTION
On the rebase to kubernetes 1.17 the metrics were moved to
"k8s.io/component-base/metrics/legacyregistry" as part of:
https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
But we were using the old endpoint which was
github.com/prometheus/client_golang/prometheus .

This effort is work in progress so I expect to have problems in future
rebases, most certainly we won't face issues here on the 1.18 and 1.19
rebases.