### PR TITLE
Bug 1810505: Pass -w to iptables when adding anti-metadata-server rules

### DIFF
--- a/cmd/sdn-cni-plugin/openshift-sdn_linux.go
+++ b/cmd/sdn-cni-plugin/openshift-sdn_linux.go
@@ -247,7 +247,7 @@ func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {
 
 		// Block access to certain things
 		for _, args := range iptablesCommands {
-			out, err := exec.Command("iptables", args...).CombinedOutput()
+			out, err := exec.Command("iptables", append([]string{"-w"}, args...)...).CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("could not set up pod iptables rules: %s", string(out))
 			}


### PR DESCRIPTION
The hack to add iptables rules blocking 169.254.169.254 calls iptables directly rather than using k8s's wrapper around it, so it wasn't using `-w`, so if it got called while something else was doing an iptables update, it would fail:

    Multus: Err adding pod to network "openshift-sdn": Multus: error in invoke
    Delegate add - "openshift-sdn": could not set up pod iptables rules: Another
    app is currently holding the xtables lock. Perhaps you want to use the -w option?