### PR TITLE
Add --node-name and --node-ip flags to openshift-sdn-node

### DIFF
--- a/pkg/openshift-sdn/cmd.go
+++ b/pkg/openshift-sdn/cmd.go
@@ -31,6 +31,7 @@ type OpenShiftSDN struct {
 	URLOnlyKubeConfigFilePath string
 
 	nodeName string
+	nodeIP   string
 
 	ProxyConfig *kubeproxyconfig.KubeProxyConfiguration
 
@@ -65,6 +66,8 @@ func NewOpenShiftSDNCommand(basename string, errout io.Writer) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
+	flags.StringVar(&sdn.nodeName, "node-name", "", "Kubernetes node name")
+	flags.StringVar(&sdn.nodeIP, "node-ip", "", "Kubernetes node IP")
 	flags.StringVar(&sdn.ProxyConfigFilePath, "proxy-config", "", "Location of the kube-proxy configuration file")
 	cmd.MarkFlagRequired("proxy-config")
 	flags.StringVar(&sdn.URLOnlyKubeConfigFilePath, "url-only-kubeconfig", "", "Path to a kubeconfig file to use, but only to determine the URL to the apiserver. The in-cluster credentials will be used.")
@@ -118,7 +121,10 @@ func (sdn *OpenShiftSDN) Run(c *cobra.Command, errout io.Writer, stopCh chan str
 // ValidateAndParse validates the command line options, parses the node
 // configuration, and builds the upstream proxy configuration.
 func (sdn *OpenShiftSDN) ValidateAndParse() error {
-	sdn.nodeName = os.Getenv("K8S_NODE_NAME")
+	// Backward compatibility
+	if sdn.nodeName == "" {
+		sdn.nodeName = os.Getenv("K8S_NODE_NAME")
+	}
 
 	klog.V(2).Infof("Reading proxy configuration from %s", sdn.ProxyConfigFilePath)
 	var err error

--- a/pkg/openshift-sdn/sdn.go
+++ b/pkg/openshift-sdn/sdn.go
@@ -21,7 +21,8 @@ func (sdn *OpenShiftSDN) initSDN() error {
 
 	var err error
 	sdn.OsdnNode, err = sdnnode.New(&sdnnode.OsdnNodeConfig{
-		Hostname:           sdn.nodeName,
+		NodeName:           sdn.nodeName,
+		NodeIP:             sdn.nodeIP,
 		NetworkClient:      sdn.informers.NetworkClient,
 		KClient:            sdn.informers.KubeClient,
 		KubeInformers:      sdn.informers.KubeInformers,


### PR DESCRIPTION
openshift-sdn-node tries to figure out the node IP by resolving the node name as a hostname and/or picking a default IP off the primary network interface. While this made sense historically, there's no point in doing this now since it runs as a pod and so we can just get kubelet to tell us the "official" node IP and should do that instead.

Relatedly, while we are already getting the node name from kubelet, we were passing it in a non-obvious way via environment variable, but we should allow passing it explicitly instead.

(cf https://bugzilla.redhat.com/show_bug.cgi?id=1802557, where we seem to be autodetecting the wrong egress IP)