### PR TITLE
Bug 1813846: handle default-deny rule properely

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -577,7 +577,7 @@ func (np *networkPolicyPlugin) updateNetworkPolicy(npns *npNamespace, policy *ne
 	oldNPP, existed := npns.policies[policy.UID]
 	npns.policies[policy.UID] = npp
 
-	changed := !existed || !reflect.DeepEqual(oldNPP.flows, npp.flows)
+	changed := !existed || !reflect.DeepEqual(oldNPP.flows, npp.flows) || !reflect.DeepEqual(oldNPP.selectedIPs, npp.selectedIPs)
 	if !changed {
 		klog.V(5).Infof("NetworkPolicy %s/%s is unchanged", policy.Namespace, policy.Name)
 	}


### PR DESCRIPTION
Why this is needed:

Today the SDN networkpolicy code does not create the OVS drop flows for any pod which is created _after and matches_ a "default-deny" networkpolicy. This stems from the fact that `parseNetworkPolicy` only attaches flows to the `npPolicy` should the defined networkpolicy define a `.Spec.Ingress`, which is not always the case, as in the example for the mentioned bug. We need an additional check on the parsed 
`selectedIPs` so that this corner case can be handled and the proper OVS flows created accordingly here: https://github.com/openshift/sdn/blob/master/pkg/network/node/networkpolicy.go#L299

This will need a back-port to 4.1 eventually

/assign @danwinship  
