### PR TITLE
Bug 1820778: fix health check in standalone kube-proxy

### DIFF
--- a/glide.diff
+++ b/glide.diff
@@ -119,7 +119,7 @@ diff --no-dereference -N -r current/vendor/k8s.io/kubernetes/pkg/proxy/iptables/
 < 	// We pass syncPeriod to ipt.Monitor, which will call us only if it needs to.
 < 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner anyway though.
 < 	// time.Hour is arbitrary.
-< 	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.maybeSyncProxyRules, minSyncPeriod, time.Hour, burstSyncs)
+< 	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.maybeSyncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
 < 	go ipt.Monitor(utiliptables.Chain("KUBE-PROXY-CANARY"),
 < 		[]utiliptables.Table{utiliptables.TableMangle, utiliptables.TableNAT, utiliptables.TableFilter},
 < 		proxier.forceSyncProxyRules, syncPeriod, wait.NeverStop)

--- a/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
@@ -327,7 +327,7 @@ func NewProxier(ipt utiliptables.Interface,
 	// We pass syncPeriod to ipt.Monitor, which will call us only if it needs to.
 	// We need to pass *some* maxInterval to NewBoundedFrequencyRunner anyway though.
 	// time.Hour is arbitrary.
-	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.maybeSyncProxyRules, minSyncPeriod, time.Hour, burstSyncs)
+	proxier.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", proxier.maybeSyncProxyRules, minSyncPeriod, syncPeriod, burstSyncs)
 	go ipt.Monitor(utiliptables.Chain("KUBE-PROXY-CANARY"),
 		[]utiliptables.Table{utiliptables.TableMangle, utiliptables.TableNAT, utiliptables.TableFilter},
 		proxier.forceSyncProxyRules, syncPeriod, wait.NeverStop)


### PR DESCRIPTION
The "preserve old health/metrics behavior" patch in #39 was incorrect, but we didn't notice because we don't actually healthcheck kube-proxy when using sdn. However, we *do* healthcheck is when running a standalone kube-proxy, and now that's failing. ~(Also, the metrics should now be indicating that kube-proxy is unhealthy, but no one has noticed that, so I guess we're not alerting on the kube-proxy metrics in 4.3?)~

The problem is that we used to run `syncProxyRules` every `syncPeriod`, whether it was needed or not, and that would poke the health server and metrics to tell it that we were still healthy. With `iptables.Monitor` we no longer need to run `syncProxyRules` when nothing has changed, but that meant we weren't regularly poking the health server. Upstream this was fixed by making the health server work differently and deprecating the old metrics, but in 4.3 I put in a hack (https://github.com/openshift/sdn/pull/39/commits/d6af0d6bfcb0f7d21017c0ee10e0c61da3371f6f) to preserve the old "poke regularly" behavior by continuing to call `syncProxyRules` every `syncPeriod` but only actually updating iptables if something actually changed.

Except that I forgot to put the sync period back to `syncPeriod`.

/cc @dcbw @juanluisvaladas @squeed 

/hold
until I can confirm the fix