### PR TITLE
Bug 1822351: Fix hybrid proxier for iptables.Monitor

### DIFF
--- a/pkg/network/node/iptables.go
+++ b/pkg/network/node/iptables.go
@@ -12,16 +12,12 @@ import (
 
 	"k8s.io/klog"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/util/iptables"
-	kexec "k8s.io/utils/exec"
 )
 
 type NodeIPTables struct {
 	ipt                iptables.Interface
 	clusterNetworkCIDR []string
-	syncPeriod         time.Duration
 	masqueradeServices bool
 	vxlanPort          uint32
 	masqueradeBitHex   string // the masquerade bit as hex value
@@ -31,11 +27,10 @@ type NodeIPTables struct {
 	egressIPs map[string]string
 }
 
-func newNodeIPTables(clusterNetworkCIDR []string, syncPeriod time.Duration, masqueradeServices bool, vxlanPort uint32, masqueradeBit uint32) *NodeIPTables {
+func newNodeIPTables(ipt iptables.Interface, clusterNetworkCIDR []string, masqueradeServices bool, vxlanPort uint32, masqueradeBit uint32) *NodeIPTables {
 	return &NodeIPTables{
-		ipt:                iptables.New(kexec.New(), iptables.ProtocolIpv4),
+		ipt:                ipt,
 		clusterNetworkCIDR: clusterNetworkCIDR,
-		syncPeriod:         syncPeriod,
 		masqueradeServices: masqueradeServices,
 		vxlanPort:          vxlanPort,
 		masqueradeBitHex:   fmt.Sprintf("%#x", 1<<masqueradeBit),
@@ -47,15 +42,6 @@ func (n *NodeIPTables) Setup() error {
 	if err := n.syncIPTableRules(); err != nil {
 		return err
 	}
-
-	go n.ipt.Monitor(iptables.Chain("OPENSHIFT-SDN-CANARY"),
-		[]iptables.Table{iptables.TableMangle, iptables.TableNAT, iptables.TableFilter},
-		func() {
-			if err := n.syncIPTableRules(); err != nil {
-				utilruntime.HandleError(fmt.Errorf("Reloading openshift iptables failed: %v", err))
-			}
-		},
-		n.syncPeriod, utilwait.NeverStop)
 	return nil
 }
 

--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -121,6 +121,11 @@ func (proxy *OsdnProxy) Start(proxier kubeproxy.Provider, waitChan chan<- bool) 
 	return nil
 }
 
+func (proxy *OsdnProxy) ReloadIPTables() error {
+	proxy.Sync()
+	return nil
+}
+
 func (proxy *OsdnProxy) updateEgressNetworkPolicyLocked(policy networkv1.EgressNetworkPolicy) {
 	proxy.Lock()
 	defer proxy.Unlock()

--- a/pkg/network/proxyimpl/hybrid/proxy.go
+++ b/pkg/network/proxyimpl/hybrid/proxy.go
@@ -35,7 +35,6 @@ type HybridProxier struct {
 
 	mainProxy     RunnableProxy
 	unidlingProxy RunnableProxy
-	syncPeriod    time.Duration
 	minSyncPeriod time.Duration
 	serviceLister corev1listers.ServiceLister
 
@@ -61,14 +60,12 @@ type HybridProxier struct {
 func NewHybridProxier(
 	mainProxy RunnableProxy,
 	unidlingProxy RunnableProxy,
-	syncPeriod time.Duration,
 	minSyncPeriod time.Duration,
 	serviceLister corev1listers.ServiceLister,
 ) (*HybridProxier, error) {
 	p := &HybridProxier{
 		mainProxy:     mainProxy,
 		unidlingProxy: unidlingProxy,
-		syncPeriod:    syncPeriod,
 		minSyncPeriod: minSyncPeriod,
 		serviceLister: serviceLister,
 
@@ -76,7 +73,7 @@ func NewHybridProxier(
 		switchedToUserspace: make(map[types.NamespacedName]bool),
 	}
 
-	p.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", p.syncProxyRules, minSyncPeriod, syncPeriod, 4)
+	p.syncRunner = async.NewBoundedFrequencyRunner("sync-runner", p.syncProxyRules, minSyncPeriod, time.Hour, 4)
 
 	// Hackery abound: we want to make sure that changes are applied
 	// to both proxies at approximately the same time. That means that we

--- a/pkg/openshift-sdn/proxy.go
+++ b/pkg/openshift-sdn/proxy.go
@@ -176,7 +176,6 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		proxier, err = hybrid.NewHybridProxier(
 			hp,
 			unidlingUserspaceProxy,
-			sdn.ProxyConfig.IPTables.SyncPeriod.Duration,
 			sdn.ProxyConfig.IPTables.MinSyncPeriod.Duration,
 			sdn.informers.KubeInformers.Core().V1().Services().Lister(),
 		)

--- a/pkg/openshift-sdn/sdn.go
+++ b/pkg/openshift-sdn/sdn.go
@@ -21,16 +21,16 @@ func (sdn *OpenShiftSDN) initSDN() error {
 
 	var err error
 	sdn.OsdnNode, err = sdnnode.New(&sdnnode.OsdnNodeConfig{
-		NodeName:           sdn.nodeName,
-		NodeIP:             sdn.nodeIP,
-		NetworkClient:      sdn.informers.NetworkClient,
-		KClient:            sdn.informers.KubeClient,
-		KubeInformers:      sdn.informers.KubeInformers,
-		NetworkInformers:   sdn.informers.NetworkInformers,
-		IPTablesSyncPeriod: sdn.ProxyConfig.IPTables.SyncPeriod.Duration,
-		MasqueradeBit:      sdn.ProxyConfig.IPTables.MasqueradeBit,
-		ProxyMode:          sdn.ProxyConfig.Mode,
-		Recorder:           sdn.sdnRecorder,
+		NodeName:         sdn.nodeName,
+		NodeIP:           sdn.nodeIP,
+		NetworkClient:    sdn.informers.NetworkClient,
+		KClient:          sdn.informers.KubeClient,
+		KubeInformers:    sdn.informers.KubeInformers,
+		NetworkInformers: sdn.informers.NetworkInformers,
+		IPTables:         sdn.ipt,
+		MasqueradeBit:    sdn.ProxyConfig.IPTables.MasqueradeBit,
+		ProxyMode:        sdn.ProxyConfig.Mode,
+		Recorder:         sdn.sdnRecorder,
 	})
 	return err
 }


### PR DESCRIPTION
The iptables proxier has been fixed to not constantly resync its rules when not needed... except that the hybrid proxier was forcing it to do it anyway. Fix that by moving the NodeIPTables monitor up out to the top level of openshift-sdn-node and sharing it between the node and proxy code.

/hold
for testing