### PR TITLE
Bug 1824203: Make egressVXLANMonitor updates channel buffered

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -52,7 +52,7 @@ func newEgressIPWatcher(oc *ovsController, localIP string, masqueradeBit *int32)
 func (eip *egressIPWatcher) Start(networkInformers networkinformers.SharedInformerFactory, iptables *NodeIPTables) error {
 	eip.iptables = iptables
 
-	updates := make(chan *egressVXLANNode)
+	updates := make(chan *egressVXLANNode, 300)
 	eip.vxlanMonitor = newEgressVXLANMonitor(eip.oc.ovs, eip.tracker, updates)
 	go eip.watchVXLAN(updates)
 


### PR DESCRIPTION
The egressIPTracker has methods that lock eit.mutex and that call
evm functions that lock evm.mutex.

The problem with this is that evm.mutex has to write to the evm.updates
channel which isn't buffered and becomes blocked until
eit.setNodeOffline, which also locks eit.mutex, is running.

This causes a deadlock. By adding a buffered channel with 300 elements
we should avoid the locking problem because "640k ought to be enough
for anybody"