### PR TITLE
Bug 1781575: Discard destination unreachable from rate mask

### DIFF
--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -111,6 +111,13 @@ func (plugin *OsdnNode) SetupSDN() (bool, map[string]podNetworkInfo, error) {
 		return false, nil, fmt.Errorf("net/ipv4/ip_forward=0, it must be set to 1")
 	}
 
+	// In OCP 4 apparently we have a lot of rejects.
+	// Default rate mask is 6188, 6160 is default without destination unreachable
+	// FIXME: Why is this new to OCP 4?
+	if err = sysctl.SetSysctl("net/ipv4/icmp_ratemask", 6160); err != nil {
+		return false, nil, fmt.Errorf("Failed to setup icmp_ratemask: %s", err)
+	}
+
 	localSubnetCIDR := plugin.localSubnetCIDR
 	_, ipnet, err := net.ParseCIDR(localSubnetCIDR)
 	if err != nil {


### PR DESCRIPTION
We don't know why yet but in OCP 4.x we're hitting the ICMP rate limit and this is causing the "Services should be rejected when no endpoints exist" test to fail often.

Until we figure out why add this tunable to avoid hitting such limit

https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt

From kernel docs:
```
icmp_ratemask - INTEGER
	Mask made of ICMP types for which rates are being limited.
	Significant bits: IHGFEDCBA9876543210
	Default mask:     0000001100000011000 (6168)

	Bit definitions (see include/linux/icmp.h):
		0 Echo Reply
		3 Destination Unreachable *
```
6168 - 2³ = 6160