### PR TITLE
Bug 1839109: [backport-4.3] node/vnids: Correctly handle case where NetNamespace watch is far behind

### DIFF
--- a/pkg/network/node/vnids.go
+++ b/pkg/network/node/vnids.go
@@ -119,7 +119,7 @@ func (vmap *nodeVNIDMap) WaitAndGetVNID(name string) (uint32, error) {
 			return 0, fmt.Errorf("failed to find netid for namespace: %s, %v", name, err)
 		}
 		klog.Warningf("Netid for namespace: %s exists but not found in vnid map", name)
-		vmap.setVNID(netns.Name, netns.NetID, netnsIsMulticastEnabled(netns))
+		vmap.handleAddOrUpdateNetNamespace(netns, nil, watch.Added)
 		return netns.NetID, nil
 	}
 }


### PR DESCRIPTION
Backport of #134

When adding a pod, if the NetNamespace isn't found, we'll issue a GET
directly to the apiserver and treat it as an ADD. Except we didn't
actually handle it correctly, and caused NetworkPolicy to ignore this
NetNS forever.

Fixes: rhbz 1389109

/cc @danwinship 