### PR TITLE
Enable conntrack for ovs-multitenant

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -133,6 +133,8 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 	case networkutils.MultiTenantPluginName:
 		policy = NewMultiTenantPlugin()
 		pluginId = 1
+		minOvsVersion = "2.6.0"
+		useConnTrack = true
 	case networkutils.NetworkPolicyPluginName:
 		policy = NewNetworkPolicyPlugin()
 		pluginId = 2


### PR DESCRIPTION
ovs-multitenant needs useConntrack to cover the scenario where trying to
reach an externalIP service from a pod in a project which uses egressIP.