### PR TITLE
kube-proxy use node-ip to detect the IP family

### DIFF
--- a/pkg/openshift-sdn/proxy.go
+++ b/pkg/openshift-sdn/proxy.go
@@ -59,17 +59,19 @@ func (sdn *OpenShiftSDN) initProxy() error {
 // runProxy starts the configured proxy process and closes the provided channel
 // when the proxy has initialized
 func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
-	protocol := utiliptables.ProtocolIpv4
 	bindAddr := net.ParseIP(sdn.ProxyConfig.BindAddress)
-	if bindAddr.To4() == nil {
-		protocol = utiliptables.ProtocolIpv6
-	}
 	nodeAddr := bindAddr
-	if nodeAddr.Equal(net.IPv4zero) {
+
+	if nodeAddr.IsUnspecified() {
 		nodeAddr = net.ParseIP(sdn.nodeIP)
 		if nodeAddr == nil {
 			klog.Fatalf("Unable to parse node IP %q", sdn.nodeIP)
 		}
+	}
+
+	protocol := utiliptables.ProtocolIpv4
+	if nodeAddr.To4() == nil {
+		protocol = utiliptables.ProtocolIpv6
 	}
 
 	portRange := utilnet.ParsePortRangeOrDie(sdn.ProxyConfig.PortRange)


### PR DESCRIPTION
If the bind address is an unspecified address, 0.0.0.0 or ::,
kube-proxy uses the nodeIP to detect the IP Family.

It also fixes a minor bug where the IPv6 zero address was not
falling back to the node address.

Signed-off-by: Antonio Ojea <aojeagar@redhat.com>