### PR TITLE
Add support for --may-exist when adding the bridge in sdn

### DIFF
--- a/pkg/network/node/ovs/fake_ovs.go
+++ b/pkg/network/node/ovs/fake_ovs.go
@@ -41,7 +41,7 @@ func (fake *ovsFake) AddBridge(properties ...string) error {
 	return nil
 }
 
-func (fake *ovsFake) DeleteBridge(ifExists bool) error {
+func (fake *ovsFake) DeleteBridge() error {
 	fake.ports = nil
 	fake.flows = nil
 	return nil

--- a/pkg/network/node/ovs/ovs.go
+++ b/pkg/network/node/ovs/ovs.go
@@ -19,14 +19,13 @@ import (
 type Interface interface {
 	// AddBridge creates the bridge associated with the interface, optionally setting
 	// properties on it (as with "ovs-vsctl set Bridge ..."). If the bridge already
-	// exists this errors.
+	// exists, this will NOT result in error since it sets --may-exist internally.
 	AddBridge(properties ...string) error
 
-	// DeleteBridge deletes the bridge associated with the interface. The boolean
-	// that can be passed determines if a bridge not existing is an error. Passing
-	// true will delete bridge --if-exists, passing false will error if the bridge
-	// does not exist.
-	DeleteBridge(ifExists bool) error
+	// DeleteBridge deletes the bridge associated with the interface. This always
+	// calls del-br by passing the --if-exists flag so the resulting call
+	// will not error out if the bridge doesn't exist
+	DeleteBridge() error
 
 	// AddPort adds an interface to the bridge, requesting the indicated port
 	// number, and optionally setting properties on it (as with "ovs-vsctl set
@@ -206,7 +205,7 @@ func validateColumns(columns ...string) error {
 }
 
 func (ovsif *ovsExec) AddBridge(properties ...string) error {
-	args := []string{"add-br", ovsif.bridge}
+	args := []string{"--may-exist", "add-br", ovsif.bridge}
 	if len(properties) > 0 {
 		if err := validateColumns(properties...); err != nil {
 			return err
@@ -218,12 +217,8 @@ func (ovsif *ovsExec) AddBridge(properties ...string) error {
 	return err
 }
 
-func (ovsif *ovsExec) DeleteBridge(ifExists bool) error {
-	args := []string{"del-br", ovsif.bridge}
-
-	if ifExists {
-		args = append([]string{"--if-exists"}, args...)
-	}
+func (ovsif *ovsExec) DeleteBridge() error {
+	args := []string{"--if-exists", "del-br", ovsif.bridge}
 	_, err := ovsif.exec(OVS_VSCTL, args...)
 	return err
 }

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -71,7 +71,7 @@ func (oc *ovsController) AlreadySetUp(vxlanPort uint32) bool {
 }
 
 func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway string, mtu uint32, vxlanPort uint32) error {
-	err := oc.ovs.DeleteBridge(true)
+	err := oc.ovs.DeleteBridge()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There is a race condition between ovs and sdn pods. When sdn pod starts, it tries to check if we are `alreadySetup` by checking for 

1. tun0 link being present
2. vxlan port being present
3. resourceVersion table having a len of 1 flow.

If any of these conditions fail, we delete the bridge, and recreate it including syncing all existing pods by collating data from the db and the API server. Imagine a sequence where:

0) SDN has cached ports and interface data in `existingOFPodNetworkInfo`
1) SDN deletes the bridge in `SetupOVS()`
2) ovs daemonset script adds the bridge as a part of save/restore flows.
3) SDN tries to add the bridge, and when trying to create it fails.

At step 3. the pod restarts because the setup couldn't be completed and with that we lose all the cached ports and interface information. Now when the pod restarts, we have nothing in ovsdb and that causes the said problem we are seeing with bug: 1852618

The fix here is to now allow AddBridge to fail by passing `--may-exist` in the args list to `ovs-vsctl`