### PR TITLE
proxy: Wait until the proxy has committed to iptables before going ready

### DIFF
--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -63,7 +63,7 @@ type OsdnProxy struct {
 
 	// waitChan will be closed when both services and endpoints have
 	// been synced in the proxy
-	waitChan        chan<- bool
+	waitChan        chan<- struct{}
 	servicesSynced  bool
 	endpointsSynced bool
 
@@ -92,7 +92,7 @@ func New(networkClient networkclient.Interface, kClient kubernetes.Interface,
 	}, nil
 }
 
-func (proxy *OsdnProxy) Start(proxier kubeproxy.Provider, waitChan chan<- bool) error {
+func (proxy *OsdnProxy) Start(proxier kubeproxy.Provider, waitChan chan<- struct{}) error {
 	klog.Infof("Starting multitenant SDN proxy endpoint filter")
 
 	var err error

--- a/pkg/openshift-sdn/cmd.go
+++ b/pkg/openshift-sdn/cmd.go
@@ -163,7 +163,7 @@ func (sdn *OpenShiftSDN) Start(stopCh <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	proxyInitChan := make(chan bool)
+	proxyInitChan := make(chan struct{})
 	sdn.runProxy(proxyInitChan)
 	sdn.informers.start(stopCh)
 


### PR DESCRIPTION
Right now we wait until the proxy results are sent to the proxy before telling the Kubelet the network plugin is ready. Instead, we should wait until the proxy results are sent to the proxy AND iptables has been synced at least once before telling the kubelet network is ready.

This prevents a fairly frequent race condition where the pod on SDN starts before kube-proxy has synced once. While this is allowed, it creates unnecessary churn. A pod that is waiting for network ready is likely waiting for the full network stack - pod, sdn, and dns - and this reduces the window that it could have spurious errors.

Pods must still deal with connection refused errors, but we don't need to expose them unnecessarily.

/hold

Working with David to uncover whether this addresses the race he was seeing in apiserver startup.