### PR TITLE
update egress dns code for dual-stack...

### DIFF
--- a/pkg/network/common/dns.go
+++ b/pkg/network/common/dns.go
@@ -36,6 +36,9 @@ type DNS struct {
 	nameservers []string
 	// DNS port
 	port string
+
+	// query timeout; overridden by tests
+	timeout time.Duration
 }
 
 func NewDNS(resolverConfigFile string) (*DNS, error) {
@@ -48,6 +51,7 @@ func NewDNS(resolverConfigFile string) (*DNS, error) {
 		dnsMap:      map[string]dnsValue{},
 		nameservers: filterIPv4Servers(config.Servers),
 		port:        config.Port,
+		timeout:     5 * time.Second,
 	}, nil
 }
 
@@ -136,7 +140,7 @@ func (d *DNS) getIPsAndMinTTL(domain string) ([]net.IP, time.Duration, error) {
 			dialServer = net.JoinHostPort(server, d.port)
 		}
 		c := new(dns.Client)
-		c.Timeout = 5 * time.Second
+		c.Timeout = d.timeout
 		in, _, err := c.Exchange(msg, dialServer)
 		if err != nil {
 			return nil, defaultTTL, err

--- a/pkg/network/common/dns.go
+++ b/pkg/network/common/dns.go
@@ -8,17 +8,17 @@ import (
 
 	"github.com/miekg/dns"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilnet "k8s.io/utils/net"
 )
 
 const (
-	// defaultTTL is used if an invalid or zero TTL is provided.
-	defaultTTL = 30 * time.Minute
+	// defaultTTL the time (in seconds) used as a TTL if an invalid or zero TTL is provided.
+	defaultTTL = 30 * 60
 )
 
 type dnsValue struct {
-	// All IPv4 addresses for a given domain name
+	// All IP addresses for a given domain name
 	ips []net.IP
 	// Time-to-live value from non-authoritative/cached name server for the domain
 	ttl time.Duration
@@ -29,19 +29,25 @@ type dnsValue struct {
 type DNS struct {
 	// Protects dnsMap operations
 	lock sync.Mutex
-	// Holds dns name and its corresponding information
+	// Holds DNS name and its corresponding information
 	dnsMap map[string]dnsValue
 
-	// DNS resolvers
+	// DNS resolvers, as host:port
 	nameservers []string
-	// DNS port
-	port string
+
+	// IP Families to return results for
+	ipv4 bool
+	ipv6 bool
 
 	// query timeout; overridden by tests
 	timeout time.Duration
 }
 
-func NewDNS(resolverConfigFile string) (*DNS, error) {
+func NewDNS(resolverConfigFile string, ipv4, ipv6 bool) (*DNS, error) {
+	if !ipv4 && !ipv6 {
+		return nil, fmt.Errorf("must support at least one of IPv4 or IPv6")
+	}
+
 	config, err := dns.ClientConfigFromFile(resolverConfigFile)
 	if err != nil || config == nil {
 		return nil, fmt.Errorf("cannot initialize the resolver: %v", err)
@@ -49,8 +55,9 @@ func NewDNS(resolverConfigFile string) (*DNS, error) {
 
 	return &DNS{
 		dnsMap:      map[string]dnsValue{},
-		nameservers: filterIPv4Servers(config.Servers),
-		port:        config.Port,
+		nameservers: fixupNameservers(config.Servers, config.Port, ipv4, ipv6),
+		ipv4:        ipv4,
+		ipv6:        ipv6,
 		timeout:     5 * time.Second,
 	}, nil
 }
@@ -110,7 +117,7 @@ func (d *DNS) updateOne(dns string) (bool, error) {
 
 	ips, ttl, err := d.getIPsAndMinTTL(dns)
 	if err != nil {
-		res.nextQueryTime = time.Now().Add(defaultTTL)
+		res.nextQueryTime = time.Now().Add(defaultTTL * time.Second)
 		d.dnsMap[dns] = res
 		return false, err
 	}
@@ -126,58 +133,110 @@ func (d *DNS) updateOne(dns string) (bool, error) {
 	return changed, nil
 }
 
-func (d *DNS) getIPsAndMinTTL(domain string) ([]net.IP, time.Duration, error) {
+func (d *DNS) doOneQuery(server, domain string, rtype uint16) ([]net.IP, int, error) {
 	ips := []net.IP{}
-	ttlSet := false
-	var ttlSeconds uint32
+	ttl := defaultTTL
 
-	for _, server := range d.nameservers {
-		msg := new(dns.Msg)
-		msg.SetQuestion(dns.Fqdn(domain), dns.TypeA)
+	msg := new(dns.Msg)
+	msg.SetQuestion(dns.Fqdn(domain), rtype)
 
-		dialServer := server
-		if _, _, err := net.SplitHostPort(server); err != nil {
-			dialServer = net.JoinHostPort(server, d.port)
+	c := new(dns.Client)
+	c.Timeout = d.timeout
+	in, _, err := c.Exchange(msg, server)
+	if in == nil || err != nil {
+		return ips, ttl, err
+	}
+	if in.Rcode != dns.RcodeSuccess {
+		return ips, ttl, fmt.Errorf("failed to get a valid answer: %v", in)
+	}
+
+	for _, a := range in.Answer {
+		aTTL := int(a.Header().Ttl)
+		if aTTL < ttl && aTTL != 0 {
+			ttl = aTTL
 		}
-		c := new(dns.Client)
-		c.Timeout = d.timeout
-		in, _, err := c.Exchange(msg, dialServer)
-		if err != nil {
-			return nil, defaultTTL, err
-		}
-		if in != nil && in.Rcode != dns.RcodeSuccess {
-			return nil, defaultTTL, fmt.Errorf("failed to get a valid answer: %v", in)
-		}
 
-		if in != nil && len(in.Answer) > 0 {
-			for _, a := range in.Answer {
-				if !ttlSet || a.Header().Ttl < ttlSeconds {
-					ttlSeconds = a.Header().Ttl
-					ttlSet = true
-				}
-
-				switch t := a.(type) {
-				case *dns.A:
-					ips = append(ips, t.A)
-				}
+		switch t := a.(type) {
+		case *dns.A:
+			if rtype == dns.TypeA {
+				ips = append(ips, t.A)
+			}
+		case *dns.AAAA:
+			if rtype == dns.TypeAAAA {
+				ips = append(ips, t.AAAA)
 			}
 		}
 	}
 
-	if !ttlSet || (len(ips) == 0) {
-		return nil, defaultTTL, fmt.Errorf("IPv4 addr not found for domain: %q, nameservers: %v", domain, d.nameservers)
+	return ips, ttl, nil
+}
+
+func (d *DNS) queryServer(nameserver, domain string) ([]net.IP, int, error) {
+	if d.ipv4 && !d.ipv6 {
+		// Single-stack IPv4
+		return d.doOneQuery(nameserver, domain, dns.TypeA)
+	} else if d.ipv6 && !d.ipv4 {
+		// Single-stack IPv6
+		return d.doOneQuery(nameserver, domain, dns.TypeAAAA)
+	}
+	// else dual stack
+	ips := []net.IP{}
+	ttl := defaultTTL
+	errs := make(chan error)
+	var mutex sync.Mutex
+
+	go func() {
+		v4ips, v4ttl, v4err := d.doOneQuery(nameserver, domain, dns.TypeA)
+		mutex.Lock()
+		defer mutex.Unlock()
+		ips = append(ips, v4ips...)
+		if v4ttl < ttl {
+			ttl = v4ttl
+		}
+		errs <- v4err
+	}()
+	go func() {
+		v6ips, v6ttl, v6err := d.doOneQuery(nameserver, domain, dns.TypeAAAA)
+		mutex.Lock()
+		defer mutex.Unlock()
+		ips = append(ips, v6ips...)
+		if v6ttl < ttl {
+			ttl = v6ttl
+		}
+		errs <- v6err
+	}()
+
+	err1 := <-errs
+	err2 := <-errs
+	if len(ips) > 0 {
+		return ips, ttl, nil
+	} else if err1 != nil {
+		return ips, ttl, err1
+	} else {
+		return ips, ttl, err2
+	}
+}
+
+func (d *DNS) getIPsAndMinTTL(domain string) ([]net.IP, time.Duration, error) {
+	var ips []net.IP
+	var ttl int
+	var err error
+
+	for _, server := range d.nameservers {
+		ips, ttl, err = d.queryServer(server, domain)
+		if len(ips) > 0 {
+			break
+		}
 	}
 
-	ttl, err := time.ParseDuration(fmt.Sprintf("%ds", ttlSeconds))
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Invalid TTL value for domain: %q, err: %v, defaulting ttl=%s", domain, err, defaultTTL.String()))
-		ttl = defaultTTL
+	if len(ips) == 0 {
+		if err != nil {
+			return nil, defaultTTL, fmt.Errorf("IP address not found for domain %q: %v", domain, err)
+		} else {
+			return nil, defaultTTL, fmt.Errorf("IP address not found for domain %q", domain)
+		}
 	}
-	if ttl == 0 {
-		ttl = defaultTTL
-	}
-
-	return removeDuplicateIPs(ips), ttl, nil
+	return removeDuplicateIPs(ips), time.Duration(ttl) * time.Second, nil
 }
 
 func (d *DNS) GetNextQueryTime() (time.Time, string, bool) {
@@ -219,22 +278,34 @@ func ipsEqual(oldips, newips []net.IP) bool {
 	return true
 }
 
-func filterIPv4Servers(servers []string) []string {
-	ipv4Servers := []string{}
-	for _, server := range servers {
+// fixupNameservers ensures that each nameserver has an associated port number, and removes
+// nameservers that don't match the cluster address family (unless that would leave us with
+// no nameservers).
+func fixupNameservers(nameservers []string, defaultPort string, ipv4, ipv6 bool) []string {
+	// ipSupported maps from the return value of utilnet.IsIPv6String() to whether we support it
+	ipSupported := map[bool]bool{false: ipv4, true: ipv6}
+
+	var goodServers, badServers []string
+	for _, server := range nameservers {
 		ipString := server
 		if host, _, err := net.SplitHostPort(server); err == nil {
 			ipString = host
+		} else {
+			server = net.JoinHostPort(server, defaultPort)
 		}
 
-		if ip := net.ParseIP(ipString); ip != nil {
-			if ip.To4() != nil {
-				ipv4Servers = append(ipv4Servers, server)
-			}
+		if ipSupported[utilnet.IsIPv6String(ipString)] {
+			goodServers = append(goodServers, server)
+		} else {
+			badServers = append(badServers, server)
 		}
 	}
 
-	return ipv4Servers
+	if len(goodServers) > 0 {
+		return goodServers
+	} else {
+		return badServers
+	}
 }
 
 func removeDuplicateIPs(ips []net.IP) []net.IP {

--- a/pkg/network/common/dns_test.go
+++ b/pkg/network/common/dns_test.go
@@ -54,6 +54,12 @@ func TestAddDNS(t *testing.T) {
 			expectFailure:     false,
 		},
 		{
+			testCase:          "Test valid domain name with no response",
+			domainName:        "example.com",
+			dnsResolverOutput: "",
+			expectFailure:     true,
+		},
+		{
 			testCase:          "Test invalid domain name",
 			domainName:        "sads@#$.com",
 			dnsResolverOutput: "",
@@ -78,6 +84,8 @@ func TestAddDNS(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Test case: %s failed, err: %v", test.testCase, err)
 		}
+		// Override timeout so the "no response" test doesn't take too long
+		n.timeout = 100 * time.Millisecond
 
 		err = n.Add(test.domainName)
 		if test.expectFailure && err == nil {

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -160,7 +160,7 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 		masqBit = uint32(*c.MasqueradeBit)
 	}
 
-	egressDNS, err := common.NewEgressDNS()
+	egressDNS, err := common.NewEgressDNS(true, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -77,7 +77,7 @@ type OsdnProxy struct {
 // Called by higher layers to create the proxy plugin instance
 func New(networkClient networkclient.Interface, kClient kubernetes.Interface,
 	networkInformers networkinformers.SharedInformerFactory) (*OsdnProxy, error) {
-	egressDNS, err := common.NewEgressDNS()
+	egressDNS, err := common.NewEgressDNS(true, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This updates the egress DNS code to handle IPv6 and dual-stack. Um, not that we need that or anything, but we're going to need it in ovn-kubernetes and I happened to have this code lying around so let's just merge this before copying the code over to ovn-kubernetes...

/cc @JacobTanenbaum @juanluisvaladas 