### PR TITLE
[WIP] Bug 1850060: Make egress network policy DNS queries parallel

### DIFF
--- a/pkg/network/common/dns_test.go
+++ b/pkg/network/common/dns_test.go
@@ -189,7 +189,7 @@ func TestUpdateDNS(t *testing.T) {
 		dns.HandleFunc(test.domainName, serverFn)
 		defer dns.HandleRemove(test.domainName)
 
-		_, err = n.updateOne(test.domainName)
+		_, err = n.Update(test.domainName)
 		if test.expectFailure && err == nil {
 			t.Fatalf("Test case: %s failed, expected failure but got success", test.testCase)
 		} else if !test.expectFailure && err != nil {

--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -419,13 +419,12 @@ func (proxy *OsdnProxy) syncEgressDNSProxyFirewall() {
 		utilruntime.HandleError(fmt.Errorf("Could not get EgressNetworkPolicies: %v", err))
 		return
 	}
-
-	go utilwait.Forever(proxy.egressDNS.Sync, 0)
+	go proxy.egressDNS.HandleNameUpdates()
 
 	for {
 		policyUpdates := <-proxy.egressDNS.Updates
 		for _, policyUpdate := range policyUpdates {
-			klog.V(5).Infof("Egress dns sync: update proxy firewall for policy: %v", policyUpdate.UID)
+			klog.V(2).Infof("Egress dns sync: update proxy firewall for policy: %v", policyUpdate.UID)
 
 			policy, ok := getPolicy(policyUpdate.UID, policies)
 			if !ok {


### PR DESCRIPTION
Several customers reported timeouts after upgrading to 3.11.219 which
includes a backport of github.com/openshift/sdn/pull/72.

Because names are resolved sequentially, if a name takes a couple
seconds the names that should have been resolved during that interval
won't be updated.

By doing asynchronous name resolution we ensure that if a name takes
longer than usual the rest of dnsNames won't block.