### PR TITLE
Bug 1848478:  Invalid egressCIDR value causes sdn pods to fail on startup

### DIFF
--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -179,6 +179,11 @@ func (eit *EgressIPTracker) handleAddOrUpdateHostSubnet(obj, _ interface{}, even
 	hs := obj.(*networkv1.HostSubnet)
 	klog.V(5).Infof("Watch %s event for HostSubnet %q", eventType, hs.Name)
 
+	if err := ValidateHostSubnetEgress(hs); err != nil {
+		utilruntime.HandleError(fmt.Errorf("Ignoring invalid HostSubnet %s: %v", HostSubnetToString(hs), err))
+		return
+	}
+
 	eit.UpdateHostSubnetEgress(hs)
 }
 

--- a/pkg/network/common/validation.go
+++ b/pkg/network/common/validation.go
@@ -152,6 +152,29 @@ func ValidateHostSubnet(hs *networkapi.HostSubnet) error {
 	}
 }
 
+// ValidateHostSubnetEgress checks if the user-maintained fields of hostsubnet are valid.
+func ValidateHostSubnetEgress(hs *networkapi.HostSubnet) error {
+	allErrs := validation.ValidateObjectMeta(&hs.ObjectMeta, false, path.ValidatePathSegmentName, field.NewPath("metadata"))
+
+	for i, egressIP := range hs.EgressIPs {
+		if _, err := validateIPv4(string(egressIP)); err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("egressIPs").Index(i), egressIP, err.Error()))
+		}
+	}
+
+	for i, egressCIDR := range hs.EgressCIDRs {
+		if _, err := validateCIDRv4(string(egressCIDR)); err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("egressCIDRs").Index(i), egressCIDR, err.Error()))
+		}
+	}
+
+	if len(allErrs) > 0 {
+		return allErrs.ToAggregate()
+	}
+
+	return nil
+}
+
 func cidrsOverlap(cidr1, cidr2 *net.IPNet) bool {
 	return cidr1.Contains(cidr2.IP) || cidr2.Contains(cidr1.IP)
 }

--- a/pkg/network/common/validation.go
+++ b/pkg/network/common/validation.go
@@ -121,6 +121,7 @@ func ValidateClusterNetwork(clusterNet *networkapi.ClusterNetwork) error {
 	}
 }
 
+// ValidateHostSubnet checks if the system-maintained fields of hostsubnet are valid.
 func ValidateHostSubnet(hs *networkapi.HostSubnet) error {
 	allErrs := validation.ValidateObjectMeta(&hs.ObjectMeta, false, path.ValidatePathSegmentName, field.NewPath("metadata"))
 
@@ -142,18 +143,6 @@ func ValidateHostSubnet(hs *networkapi.HostSubnet) error {
 	// In theory this has to be IPv4, but it's possible some clusters might be limping along with IPv6 values?
 	if net.ParseIP(hs.HostIP) == nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("hostIP"), hs.HostIP, "invalid IP address"))
-	}
-
-	for i, egressIP := range hs.EgressIPs {
-		if _, err := validateIPv4(string(egressIP)); err != nil {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("egressIPs").Index(i), egressIP, err.Error()))
-		}
-	}
-
-	for i, egressCIDR := range hs.EgressCIDRs {
-		if _, err := validateCIDRv4(string(egressCIDR)); err != nil {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("egressCIDRs").Index(i), egressCIDR, err.Error()))
-		}
 	}
 
 	if len(allErrs) > 0 {


### PR DESCRIPTION
If the user sets an invalid egressCIDR value, the API accepts this
and sets it in the hostsubnet field making the user think all went
well. However in the background sdn emits a warning in the logs
saying it ignores the invalid hostsubnet value but the user does
not become aware of this. Upon restarting the sdn-node pod, the pod
fails to come up and barfs that the egressCIDR is invalid.

This patch fixes this by making the sdn-controller wipe out the
invalid egressCIDR/IP field once the validation fails. This is the
same mechanism that the controller uses upon start-up when it comes
across an invalid hostsubnet.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>