### PR TITLE
 [release-4.5] Bug 1874798: Add NodeInformer to EgressIP

### DIFF
--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -115,7 +115,7 @@ func (master *OsdnMaster) startSubSystems(pluginName string) {
 	}
 
 	eim := newEgressIPManager()
-	eim.Start(master.networkClient, master.hostSubnetInformer, master.netNamespaceInformer)
+	eim.Start(master.networkClient, master.hostSubnetInformer, master.netNamespaceInformer, master.nodeInformer)
 }
 
 func (master *OsdnMaster) checkClusterNetworkAgainstLocalNetworks() error {


### PR DESCRIPTION
Backport for https://github.com/openshift/sdn/pull/171 https://github.com/openshift/sdn/pull/175
=======

* Refactor logic
* Fix calling nodeInformer in EgressIPManager.
* Add NodeInformer to EgressIP