### PR TITLE
[release-4.4] Bug 1874799: Add NodeInformer to EgressIP

### DIFF
--- a/pkg/network/master/egressip.go
+++ b/pkg/network/master/egressip.go
@@ -47,9 +47,10 @@ func newEgressIPManager() *egressIPManager {
 	return eim
 }
 
-func (eim *egressIPManager) Start(networkClient networkclient.Interface, hostSubnetInformer networkinformers.HostSubnetInformer, netNamespaceInformer networkinformers.NetNamespaceInformer) {
+func (eim *egressIPManager) Start(networkClient networkclient.Interface, hostSubnetInformer networkinformers.HostSubnetInformer, netNamespaceInformer networkinformers.NetNamespaceInformer, nodeInformer kcoreinformers.NodeInformer) {
 	eim.networkClient = networkClient
 	eim.hostSubnetInformer = hostSubnetInformer
+	eim.nodeInformer = nodeInformer
 	eim.tracker.Start(hostSubnetInformer, netNamespaceInformer)
 }
 
@@ -161,6 +162,16 @@ func (eim *egressIPManager) poll(stop chan struct{}) {
 	}
 }
 
+func isNodeConditionGood(cond v1.NodeCondition) bool {
+	isNodeGood := true
+	if cond.Type == v1.NodeReady {
+		if cond.Status == v1.ConditionFalse || cond.Status == v1.ConditionUnknown {
+			isNodeGood = false
+		}
+	}
+	return isNodeGood
+}
+
 func (eim *egressIPManager) check(retrying bool) (bool, error) {
 	var timeout time.Duration
 	if retrying {
@@ -181,12 +192,12 @@ func (eim *egressIPManager) check(retrying bool) (bool, error) {
 		}
 
 		for _, cond := range nn.Status.Conditions {
-			if cond.Type == v1.TaintNodeNotReady {
-				klog.Warningf("Node %s is not Ready", node.ip)
+			if !isNodeConditionGood(cond) {
+				klog.Warningf("Node %s is not Ready", node.name)
 				node.offline = true
 				eim.tracker.SetNodeOffline(node.ip, true)
 				// Return when there's a not Ready node
-				return true, nil
+				return false, nil
 			}
 		}
 

--- a/pkg/network/master/egressip.go
+++ b/pkg/network/master/egressip.go
@@ -162,14 +162,16 @@ func (eim *egressIPManager) poll(stop chan struct{}) {
 	}
 }
 
-func isNodeConditionGood(cond v1.NodeCondition) bool {
-	isNodeGood := true
-	if cond.Type == v1.NodeReady {
-		if cond.Status == v1.ConditionFalse || cond.Status == v1.ConditionUnknown {
-			isNodeGood = false
+func nodeIsReady(node *v1.Node) bool {
+	nodeReady := true
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == v1.NodeReady {
+			if cond.Status == v1.ConditionFalse || cond.Status == v1.ConditionUnknown {
+				nodeReady = false
+			}
 		}
 	}
-	return isNodeGood
+	return nodeReady
 }
 
 func (eim *egressIPManager) check(retrying bool) (bool, error) {
@@ -188,17 +190,15 @@ func (eim *egressIPManager) check(retrying bool) (bool, error) {
 
 		nn, err := eim.nodeInformer.Lister().Get(node.name)
 		if err != nil {
-			klog.Warningf("Couldn't get node %s ", node.ip)
+			return false, err
 		}
 
-		for _, cond := range nn.Status.Conditions {
-			if !isNodeConditionGood(cond) {
-				klog.Warningf("Node %s is not Ready", node.name)
-				node.offline = true
-				eim.tracker.SetNodeOffline(node.ip, true)
-				// Return when there's a not Ready node
-				return false, nil
-			}
+		if !nodeIsReady(nn) {
+			klog.Warningf("Node %s is not Ready", node.name)
+			node.offline = true
+			eim.tracker.SetNodeOffline(node.ip, true)
+			// Return when there's a not Ready node
+			return false, nil
 		}
 
 		online := eim.tracker.Ping(node.ip, timeout)

--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -114,7 +114,7 @@ func (master *OsdnMaster) startSubSystems(pluginName string) {
 	}
 
 	eim := newEgressIPManager()
-	eim.Start(master.networkClient, master.hostSubnetInformer, master.netNamespaceInformer)
+	eim.Start(master.networkClient, master.hostSubnetInformer, master.netNamespaceInformer, master.nodeInformer)
 }
 
 func (master *OsdnMaster) checkClusterNetworkAgainstLocalNetworks() error {


### PR DESCRIPTION
Backport for https://github.com/openshift/sdn/pull/171 https://github.com/openshift/sdn/pull/175
=======

* Refactor logic
* Fix calling nodeInformer in EgressIPManager.
* Add NodeInformer to EgressIP