### PR TITLE
Bug 1812333: Fix error handling from DNS nameservers

### DIFF
--- a/pkg/network/common/dns.go
+++ b/pkg/network/common/dns.go
@@ -10,6 +10,7 @@ import (
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog"
 )
 
 const (
@@ -142,7 +143,8 @@ func (d *DNS) getIPsAndMinTTL(domain string) ([]net.IP, time.Duration, error) {
 			return nil, defaultTTL, err
 		}
 		if in != nil && in.Rcode != dns.RcodeSuccess {
-			return nil, defaultTTL, fmt.Errorf("failed to get a valid answer: %v", in)
+			klog.Warningf("failed to get a valid answer: %v from nameserver: %s for domain: %s", in.Rcode, server, domain)
+			continue
 		}
 
 		if in != nil && len(in.Answer) > 0 {


### PR DESCRIPTION
Egress network policy should be able to resolve DNS names. If
multiple DNS servers are listed in /etc/resolv.conf and one of these
returns an NXDOMAIN response, we, in turn, return an error and
skip testing any succeeding nameserver.

Instead of returning an error, just continue to the next one.

This also modifies the log output from the verbose:

```
E0914 09:07:04.465928  834879 dns.go:146] failed to get a valid answer: ;; opcode: QUERY, status: NXDOMAIN, id: 8469
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 0

;; QUESTION SECTION:
;pod2.ec2.internal.	IN	 A

;; AUTHORITY SECTION:
.	9454	IN	SOA	a.root-servers.net. nstld.verisign-grs.com. 2020030401 1800 900 604800 86400
E0304 10:00:10.168990 1004855 egress_dns.go:64] failed to get a valid answer: ;; opcode: QUERY, status: NXDOMAIN, id: 7927
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 0

;; QUESTION SECTION:
;pod2.ec2.internal.	IN	 A

;; AUTHORITY SECTION:
.	9454	IN	SOA	a.root-servers.net. nstld.verisign-grs.com. 2020030401 1800 900 604800 86400
```

to a more short and concrete output:

```
W0914 09:07:04.465928  834879 dns.go:146] failed to get a valid answer: 3 from nameserver: 10.11.5.19 for domain: pod2.ec2.internal
```
 


Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>