### PR TITLE
 Bug 1762580: Enable conntrack for ovs-multitenant unless userspace proxy

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -134,6 +134,10 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 	case networkutils.MultiTenantPluginName:
 		policy = NewMultiTenantPlugin()
 		pluginId = 1
+		// Userspace proxy is incompatible with conntrack.
+		if c.ProxyMode != kubeproxyconfig.ProxyModeUserspace {
+			useConnTrack = true
+		}
 	case networkutils.NetworkPolicyPluginName:
 		policy = NewNetworkPolicyPlugin()
 		pluginId = 2

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -125,7 +125,6 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 
 	var policy osdnPolicy
 	var pluginId int
-	var minOvsVersion string
 	var useConnTrack bool
 	switch strings.ToLower(networkInfo.PluginName) {
 	case networkutils.SingleTenantPluginName:
@@ -141,7 +140,6 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 	case networkutils.NetworkPolicyPluginName:
 		policy = NewNetworkPolicyPlugin()
 		pluginId = 2
-		minOvsVersion = "2.6.0"
 		useConnTrack = true
 	default:
 		return nil, fmt.Errorf("Unknown plugin name %q", networkInfo.PluginName)
@@ -153,7 +151,7 @@ func New(c *OsdnNodeConfig) (*OsdnNode, error) {
 
 	klog.Infof("Initializing SDN node %q (%s) of type %q", c.NodeName, c.NodeIP, networkInfo.PluginName)
 
-	ovsif, err := ovs.New(kexec.New(), Br0, minOvsVersion)
+	ovsif, err := ovs.New(kexec.New(), Br0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/node/ovs/ovs_test.go
+++ b/pkg/network/node/ovs/ovs_test.go
@@ -74,7 +74,7 @@ func ensureInputFlows(t *testing.T, fakeCmd *fakeexec.FakeCmd, flows []string) {
 func TestTransactionSuccess(t *testing.T) {
 	fexec := normalSetup()
 
-	ovsif, err := New(fexec, "br0", "")
+	ovsif, err := New(fexec, "br0")
 	if err != nil {
 		t.Fatalf("Unexpected error from ovs.New(): %v", err)
 	}
@@ -156,7 +156,7 @@ func TestDumpFlows(t *testing.T) {
  cookie=0x0, duration=13284.67s, table=0, n_packets=782815611, n_bytes=179416494325, priority=50 actions=output:2
 `, nil)
 
-	ovsif, err := New(fexec, "br0", "")
+	ovsif, err := New(fexec, "br0")
 	if err != nil {
 		t.Fatalf("Unexpected error from ovs.New(): %v", err)
 	}
@@ -177,7 +177,7 @@ func TestDumpFlows(t *testing.T) {
 
 func TestOVSMissing(t *testing.T) {
 	fexec := missingSetup()
-	ovsif, err := New(fexec, "br0", "")
+	ovsif, err := New(fexec, "br0")
 	if err == nil || ovsif != nil {
 		t.Fatalf("Unexpectedly did not get error")
 	}
@@ -188,7 +188,7 @@ func TestOVSMissing(t *testing.T) {
 
 func TestAddPort(t *testing.T) {
 	fexec := normalSetup()
-	ovsif, err := New(fexec, "br0", "")
+	ovsif, err := New(fexec, "br0")
 	if err != nil {
 		t.Fatalf("Unexpected error from ovs.New(): %v", err)
 	}
@@ -261,29 +261,9 @@ func TestAddPort(t *testing.T) {
 	ensureTestResults(t, fexec)
 }
 
-func TestOVSVersion(t *testing.T) {
-	fexec := normalSetup()
-	defer ensureTestResults(t, fexec)
-
-	addTestResult(t, fexec, "ovs-vsctl --timeout=30 --version", "2.5.0", nil)
-	if _, err := New(fexec, "br0", "2.5.0"); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	addTestResult(t, fexec, "ovs-vsctl --timeout=30 --version", "2.4.0", nil)
-	if _, err := New(fexec, "br0", "2.5.0"); err == nil {
-		t.Fatalf("Unexpectedly did not get error")
-	}
-
-	addTestResult(t, fexec, "ovs-vsctl --timeout=30 --version", "3.2.0", nil)
-	if _, err := New(fexec, "br0", "2.5.0"); err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-}
-
 func TestFind(t *testing.T) {
 	fexec := normalSetup()
-	ovsif, err := New(fexec, "br0", "")
+	ovsif, err := New(fexec, "br0")
 	if err != nil {
 		t.Fatalf("Unexpected error from ovs.New(): %v", err)
 	}


### PR DESCRIPTION
Should I do the same for ovs-subnet as well? I think it makes sense but I doubt anyone actually cares about this in ovs-subnet.

/assign @danwinship 