### PR TITLE
Bug 1878787: vxlan_monitor_test: fix flake

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 )
 
 replace (
+	bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/certifi/gocertifi => github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2
 	github.com/containernetworking/cni => github.com/containernetworking/cni v0.6.0-rc1
 	github.com/containernetworking/plugins => github.com/containernetworking/plugins v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
 bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690/go.mod h1:Ulb78X89vxKYgdL24HMTiXYHlyHEvruOj1ZPlqeNEZM=
-bitbucket.org/ww/goautoneg v0.0.0-20120707110453-75cd24fc2f2c/go.mod h1:1vhO7Mn/FZMgOgDVGLy5X1mE6rq1HbkBdkF/yj8zkcg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -397,6 +396,7 @@ github.com/mozilla/tls-observatory v0.0.0-20180409132520-8791a200eb40/go.mod h1:
 github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618/go.mod h1:x8F1gnqOkIEiO4rqoeEEEqQbo7HjGMTvyoq3gej4iT0=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d h1:7PxY7LVfSZm7PEeBTyK1rj1gABdCO2mbri6GKO1cMDs=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mvdan/xurls v1.1.0/go.mod h1:tQlNn3BED8bE/15hnSL2HLkDeLWpNPAwtw7wkEq44oU=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=

--- a/pkg/network/node/vxlan_monitor_test.go
+++ b/pkg/network/node/vxlan_monitor_test.go
@@ -254,20 +254,19 @@ func TestEgressVXLANMonitor(t *testing.T) {
 	}
 
 	update := peekUpdate(updates, evm)
-	// Because we're doing the node updates sequentially we can expect
-	// the nodes to be marked offline in a specific order.
-	// It doesn't really matter, but it's unexpected enough to raise an error.
 	if update == nil {
 		t.Fatalf("Nodes failed to go offline")
-	} else if update[0].nodeIP != "192.168.1.1" {
-		t.Fatalf("Expected update[0] to be 192.168.1.1: %#v", update)
-	} else if !update[0].offline {
-		t.Fatalf("192.168.1.1 unexpectedly online: %#v", update)
-	} else if update[1].nodeIP != "192.168.1.3" {
-		t.Fatalf("Expected update[1] to be 192.168.1.3: %#v", update)
-	} else if !update[1].offline {
-		t.Fatalf("192.168.1.3 unexpectedly online: %#v", update)
 	} else if len(update) != 2 {
-		t.Fatalf("Check erroneously showed additional updated nodes %#v", update)
+		t.Fatalf("Check return wrong number of updates %#v", update)
+	}
+
+	// GetUpdates returns the updates in a random order
+	if !(update[0].nodeIP == "192.168.1.1" && update[1].nodeIP == "192.168.1.3") &&
+		!(update[0].nodeIP == "192.168.1.3" && update[1].nodeIP == "192.168.1.1") {
+		t.Fatalf("Expected one update for 192.168.1.1 and one for 192.168.1.3: %#v", update)
+	} else if !update[0].offline {
+		t.Fatalf("%s unexpectedly online: %#v", update[0].nodeIP, update)
+	} else if !update[1].offline {
+		t.Fatalf("%s unexpectedly online: %#v", update[1].nodeIP, update)
 	}
 }


### PR DESCRIPTION
Replaces #190, adds a commit to fix "make verify-deps" which got broken by a disappeared upstream module. (The two commits have nothing to do with each other but I don't feel like filing a bz to let me fix the verify-deps bug separately.)
