### PR TITLE
Allow running openshift-sdn with standalone kube-proxy

### DIFF
--- a/pkg/openshift-sdn/cmd.go
+++ b/pkg/openshift-sdn/cmd.go
@@ -189,8 +189,10 @@ func (sdn *OpenShiftSDN) reloadIPTables() {
 	if err := sdn.OsdnNode.ReloadIPTables(); err != nil {
 		utilruntime.HandleError(fmt.Errorf("Reloading openshift node iptables rules failed: %v", err))
 	}
-	if err := sdn.OsdnProxy.ReloadIPTables(); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Reloading openshift proxy iptables rules failed: %v", err))
+	if sdn.OsdnProxy != nil {
+		if err := sdn.OsdnProxy.ReloadIPTables(); err != nil {
+			utilruntime.HandleError(fmt.Errorf("Reloading openshift proxy iptables rules failed: %v", err))
+		}
 	}
 }
 

--- a/pkg/openshift-sdn/proxy.go
+++ b/pkg/openshift-sdn/proxy.go
@@ -59,6 +59,12 @@ func (sdn *OpenShiftSDN) initProxy() error {
 // runProxy starts the configured proxy process and closes the provided channel
 // when the proxy has initialized
 func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
+	if string(sdn.ProxyConfig.Mode) == "disabled" {
+		klog.Warningf("Built-in kube-proxy is disabled")
+		close(waitChan)
+		return
+	}
+
 	bindAddr := net.ParseIP(sdn.ProxyConfig.BindAddress)
 	nodeAddr := bindAddr
 


### PR DESCRIPTION
Spinoff of https://github.com/openshift/cluster-network-operator/pull/819; along with an upcoming CNO PR this will allow us to run openshift-sdn with a standalone kube-proxy for testing