### PR TITLE
Dockerfile: add tcpdump for debugging

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -15,7 +15,7 @@ RUN INSTALL_PKGS=" \
       libmnl libnetfilter_conntrack conntrack-tools \
       libnfnetlink iproute procps-ng openssl \
       iputils binutils xz util-linux dbus nftables \
-      " && \
+      tcpdump" && \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     mkdir -p /etc/sysconfig/cni/net.d && \
     yum clean all && rm -rf /var/cache/*


### PR DESCRIPTION
We'll not infrequently try to debug, and this is easier and
less error prone than trying to 'oc debug node' and run toolbox.

@stevekuznetsov @danwinship @juanluisvaladas 