### PR TITLE
Bug 1878845: Fix ruleversion

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -36,7 +36,7 @@ const (
 	Vxlan0 = "vxlan0"
 
 	// rule versioning; increment each time flow rules change
-	ruleVersion = 7
+	ruleVersion = 8
 
 	ruleVersionTable = 253
 )

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -98,7 +98,7 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 
 	// Table 0: initial dispatch based on in_port
 	if oc.useConnTrack {
-		otx.AddFlow("table=0, priority=300, ip, ct_state=-trk, actions=ct(table=0)")
+		otx.AddFlow("table=0, priority=1000, ip, ct_state=-trk, actions=ct(table=0)")
 	}
 	// vxlan0
 	for _, clusterCIDR := range clusterNetworkCIDR {


### PR DESCRIPTION
In commit a464217b we changed the flows but forgot to increase the ruleVersion. This breaks upgrades in multitenant.

Also since we're here another little bug that isn't breaking anything right now. Initially 300 was the highest priority but now we have a rule that is 400, make it 1000 so that it's guaranteed that the flow is always evaluated.
