### PR TITLE
Bug 1891454: Fix error handling from DNS nameservers

### DIFF
--- a/pkg/network/common/dns.go
+++ b/pkg/network/common/dns.go
@@ -10,6 +10,7 @@ import (
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog"
 )
 
 const (
@@ -139,10 +140,12 @@ func (d *DNS) getIPsAndMinTTL(domain string) ([]net.IP, time.Duration, error) {
 		c.Timeout = 5 * time.Second
 		in, _, err := c.Exchange(msg, dialServer)
 		if err != nil {
-			return nil, defaultTTL, err
+			klog.Warningf("failed to query nameserver: %s with address: %s for domain: %s, err: %v", server, dialServer, domain, err)
+			continue
 		}
 		if in != nil && in.Rcode != dns.RcodeSuccess {
-			return nil, defaultTTL, fmt.Errorf("failed to get a valid answer: %v", in)
+			klog.Warningf("failed to get a valid answer: %v from nameserver: %s for domain: %s", in.Rcode, server, domain)
+			continue
 		}
 
 		if in != nil && len(in.Answer) > 0 {


### PR DESCRIPTION
This was done on master with PR #188. However I closed that, since PR #164 managed to slip in and fix the problem before 188. 164 is however a bit to big and not intended to be back-ported. So let's do this instead. 

Egress network policy should be able to resolve DNS names. If
multiple DNS servers are listed in /etc/resolv.conf and one of these
returns an NXDOMAIN response, we, in turn, return an error and
skip testing any succeeding nameserver.

Instead of returning an error, just continue to the next one.

/assign @danwinship 
