### PR TITLE
Bug 1891457: Fix error handling from DNS nameservers

### DIFF
--- a/pkg/network/common/dns.go
+++ b/pkg/network/common/dns.go
@@ -10,6 +10,7 @@ import (
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog"
 )
 
 const (
@@ -142,7 +143,8 @@ func (d *DNS) getIPsAndMinTTL(domain string) ([]net.IP, time.Duration, error) {
 			return nil, defaultTTL, err
 		}
 		if in != nil && in.Rcode != dns.RcodeSuccess {
-			return nil, defaultTTL, fmt.Errorf("failed to get a valid answer: %v", in)
+			klog.Warningf("failed to get a valid answer: %v from nameserver: %s for domain: %s", in.Rcode, server, domain)
+			continue
 		}
 
 		if in != nil && len(in.Answer) > 0 {


### PR DESCRIPTION
4.4 back-port of #211 

Egress network policy should be able to resolve DNS names. If
multiple DNS servers are listed in /etc/resolv.conf and one of these
returns an NXDOMAIN response, we, in turn, return an error and
skip testing any succeeding nameserver.

Instead of returning an error, just continue to the next one.

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>