### PR TITLE
[release-4.5] UPSTREAM<carry>: Bug 1880341: Fix bug in reflector not recovering from "Too large resource version"

### DIFF
--- a/deps.diff
+++ b/deps.diff
@@ -1,0 +1,113 @@
+diff --no-dereference -N -r current/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go updated/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+876,878d875
+< 	// CauseTypeResourceVersionTooLarge is used to report that the requested resource version
+< 	// is newer than the data observed by the API server, so the request cannot be served.
+< 	CauseTypeResourceVersionTooLarge CauseType = "ResourceVersionTooLarge"
+diff --no-dereference -N -r current/vendor/k8s.io/apiserver/pkg/storage/errors.go updated/vendor/k8s.io/apiserver/pkg/storage/errors.go
+180,185c180
+< 	err.ErrStatus.Details.Causes = []metav1.StatusCause{
+< 		{
+< 			Type:    metav1.CauseTypeResourceVersionTooLarge,
+< 			Message: tooLargeResourceVersionCauseMsg,
+< 		},
+< 	}
+---
+> 	err.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: tooLargeResourceVersionCauseMsg}}
+194c189,199
+< 	return errors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge)
+---
+> 	switch t := err.(type) {
+> 	case errors.APIStatus:
+> 		if d := t.Status().Details; d != nil {
+> 			for _, cause := range d.Causes {
+> 				if cause.Message == tooLargeResourceVersionCauseMsg {
+> 					return true
+> 				}
+> 			}
+> 		}
+> 	}
+> 	return false
+diff --no-dereference -N -r current/vendor/k8s.io/client-go/tools/cache/reflector.go updated/vendor/k8s.io/client-go/tools/cache/reflector.go
+85,87c85,87
+< 	// isLastSyncResourceVersionUnavailable is true if the previous list or watch request with
+< 	// lastSyncResourceVersion failed with an "expired" or "too large resource version" error.
+< 	isLastSyncResourceVersionUnavailable bool
+---
+> 	// isLastSyncResourceVersionGone is true if the previous list or watch request with lastSyncResourceVersion
+> 	// failed with an HTTP 410 (Gone) status code.
+> 	isLastSyncResourceVersionGone bool
+259,261c259,261
+< 			if isExpiredError(err) || isTooLargeResourceVersionError(err) {
+< 				r.setIsLastSyncResourceVersionUnavailable(true)
+< 				// Retry immediately if the resource version used to list is unavailable.
+---
+> 			if isExpiredError(err) {
+> 				r.setIsLastSyncResourceVersionExpired(true)
+> 				// Retry immediately if the resource version used to list is expired.
+263,266c263,265
+< 				// continuation pages, but the pager might not be enabled, the full list might fail because the
+< 				// resource version it is listing at is expired or the cache may not yet be synced to the provided
+< 				// resource version. So we need to fallback to resourceVersion="" in all to recover and ensure
+< 				// the reflector makes forward progress.
+---
+> 				// continuation pages, but the pager might not be enabled, or the full list might fail because the
+> 				// resource version it is listing at is expired, so we need to fallback to resourceVersion="" in all
+> 				// to recover and ensure the reflector makes forward progress.
+296c295
+< 		r.setIsLastSyncResourceVersionUnavailable(false) // list was successful
+---
+> 		r.setIsLastSyncResourceVersionExpired(false) // list was successful
+374c373
+< 				// Don't set LastSyncResourceVersionUnavailable - LIST call with ResourceVersion=RV already
+---
+> 				// Don't set LastSyncResourceVersionExpired - LIST call with ResourceVersion=RV already
+400c399
+< 					// Don't set LastSyncResourceVersionUnavailable - LIST call with ResourceVersion=RV already
+---
+> 					// Don't set LastSyncResourceVersionExpired - LIST call with ResourceVersion=RV already
+523c522
+< 	if r.isLastSyncResourceVersionUnavailable {
+---
+> 	if r.isLastSyncResourceVersionGone {
+525c524
+< 		// if the lastSyncResourceVersion is unavailable, we set ResourceVersion="" and list again to re-establish reflector
+---
+> 		// if the lastSyncResourceVersion is expired, we set ResourceVersion="" and list again to re-establish reflector
+537,539c536,538
+< // setIsLastSyncResourceVersionUnavailable sets if the last list or watch request with lastSyncResourceVersion returned
+< // "expired" or "too large resource version" error.
+< func (r *Reflector) setIsLastSyncResourceVersionUnavailable(isUnavailable bool) {
+---
+> // setIsLastSyncResourceVersionExpired sets if the last list or watch request with lastSyncResourceVersion returned a
+> // expired error: HTTP 410 (Gone) Status Code.
+> func (r *Reflector) setIsLastSyncResourceVersionExpired(isExpired bool) {
+542c541
+< 	r.isLastSyncResourceVersionUnavailable = isUnavailable
+---
+> 	r.isLastSyncResourceVersionGone = isExpired
+551,575d549
+< }
+< 
+< func isTooLargeResourceVersionError(err error) bool {
+< 	if apierrors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge) {
+< 		return true
+< 	}
+< 	// In Kubernetes 1.17.0-1.18.5, the api server doesn't set the error status cause to
+< 	// metav1.CauseTypeResourceVersionTooLarge to indicate that the requested minimum resource
+< 	// version is larger than the largest currently available resource version. To ensure backward
+< 	// compatibility with these server versions we also need to detect the error based on the content
+< 	// of the error message field.
+< 	if !apierrors.IsTimeout(err) {
+< 		return false
+< 	}
+< 	apierr, ok := err.(apierrors.APIStatus)
+< 	if !ok || apierr == nil || apierr.Status().Details == nil {
+< 		return false
+< 	}
+< 	for _, cause := range apierr.Status().Details.Causes {
+< 		// Matches the message returned by api server 1.17.0-1.18.5 for this error condition
+< 		if cause.Message == "Too large resource version" {
+< 			return true
+< 		}
+< 	}
+< 	return false

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -873,6 +873,9 @@ const (
 	// FieldManagerConflict is used to report when another client claims to manage this field,
 	// It should only be returned for a request using server-side apply.
 	CauseTypeFieldManagerConflict CauseType = "FieldManagerConflict"
+	// CauseTypeResourceVersionTooLarge is used to report that the requested resource version
+	// is newer than the data observed by the API server, so the request cannot be served.
+	CauseTypeResourceVersionTooLarge CauseType = "ResourceVersionTooLarge"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/k8s.io/apiserver/pkg/storage/errors.go
+++ b/vendor/k8s.io/apiserver/pkg/storage/errors.go
@@ -177,7 +177,12 @@ var tooLargeResourceVersionCauseMsg = "Too large resource version"
 // a minimum resource version that is larger than the largest currently available resource version for a requested resource.
 func NewTooLargeResourceVersionError(minimumResourceVersion, currentRevision uint64, retrySeconds int) error {
 	err := errors.NewTimeoutError(fmt.Sprintf("Too large resource version: %d, current: %d", minimumResourceVersion, currentRevision), retrySeconds)
-	err.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: tooLargeResourceVersionCauseMsg}}
+	err.ErrStatus.Details.Causes = []metav1.StatusCause{
+		{
+			Type:    metav1.CauseTypeResourceVersionTooLarge,
+			Message: tooLargeResourceVersionCauseMsg,
+		},
+	}
 	return err
 }
 
@@ -186,15 +191,5 @@ func IsTooLargeResourceVersion(err error) bool {
 	if !errors.IsTimeout(err) {
 		return false
 	}
-	switch t := err.(type) {
-	case errors.APIStatus:
-		if d := t.Status().Details; d != nil {
-			for _, cause := range d.Causes {
-				if cause.Message == tooLargeResourceVersionCauseMsg {
-					return true
-				}
-			}
-		}
-	}
-	return false
+	return errors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge)
 }

--- a/vendor/k8s.io/client-go/tools/cache/reflector.go
+++ b/vendor/k8s.io/client-go/tools/cache/reflector.go
@@ -551,5 +551,26 @@ func isExpiredError(err error) bool {
 }
 
 func isTooLargeResourceVersionError(err error) bool {
-	return apierrors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge)
+	if apierrors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge) {
+		return true
+	}
+	// In Kubernetes 1.17.0-1.18.5, the api server doesn't set the error status cause to
+	// metav1.CauseTypeResourceVersionTooLarge to indicate that the requested minimum resource
+	// version is larger than the largest currently available resource version. To ensure backward
+	// compatibility with these server versions we also need to detect the error based on the content
+	// of the error message field.
+	if !apierrors.IsTimeout(err) {
+		return false
+	}
+	apierr, ok := err.(apierrors.APIStatus)
+	if !ok || apierr == nil || apierr.Status().Details == nil {
+		return false
+	}
+	for _, cause := range apierr.Status().Details.Causes {
+		// Matches the message returned by api server 1.17.0-1.18.5 for this error condition
+		if cause.Message == "Too large resource version" {
+			return true
+		}
+	}
+	return false
 }

--- a/vendor/k8s.io/client-go/tools/cache/reflector.go
+++ b/vendor/k8s.io/client-go/tools/cache/reflector.go
@@ -82,9 +82,9 @@ type Reflector struct {
 	// observed when doing a sync with the underlying store
 	// it is thread safe, but not synchronized with the underlying store
 	lastSyncResourceVersion string
-	// isLastSyncResourceVersionGone is true if the previous list or watch request with lastSyncResourceVersion
-	// failed with an HTTP 410 (Gone) status code.
-	isLastSyncResourceVersionGone bool
+	// isLastSyncResourceVersionUnavailable is true if the previous list or watch request with
+	// lastSyncResourceVersion failed with an "expired" or "too large resource version" error.
+	isLastSyncResourceVersionUnavailable bool
 	// lastSyncResourceVersionMutex guards read/write access to lastSyncResourceVersion
 	lastSyncResourceVersionMutex sync.RWMutex
 	// WatchListPageSize is the requested chunk size of initial and resync watch lists.
@@ -256,13 +256,14 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			}
 
 			list, paginatedResult, err = pager.List(context.Background(), options)
-			if isExpiredError(err) {
-				r.setIsLastSyncResourceVersionExpired(true)
-				// Retry immediately if the resource version used to list is expired.
+			if isExpiredError(err) || isTooLargeResourceVersionError(err) {
+				r.setIsLastSyncResourceVersionUnavailable(true)
+				// Retry immediately if the resource version used to list is unavailable.
 				// The pager already falls back to full list if paginated list calls fail due to an "Expired" error on
-				// continuation pages, but the pager might not be enabled, or the full list might fail because the
-				// resource version it is listing at is expired, so we need to fallback to resourceVersion="" in all
-				// to recover and ensure the reflector makes forward progress.
+				// continuation pages, but the pager might not be enabled, the full list might fail because the
+				// resource version it is listing at is expired or the cache may not yet be synced to the provided
+				// resource version. So we need to fallback to resourceVersion="" in all to recover and ensure
+				// the reflector makes forward progress.
 				list, paginatedResult, err = pager.List(context.Background(), metav1.ListOptions{ResourceVersion: r.relistResourceVersion()})
 			}
 			close(listCh)
@@ -292,7 +293,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			r.paginatedResult = true
 		}
 
-		r.setIsLastSyncResourceVersionExpired(false) // list was successful
+		r.setIsLastSyncResourceVersionUnavailable(false) // list was successful
 		initTrace.Step("Objects listed")
 		listMetaInterface, err := meta.ListAccessor(list)
 		if err != nil {
@@ -370,7 +371,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 		if err != nil {
 			switch {
 			case isExpiredError(err):
-				// Don't set LastSyncResourceVersionExpired - LIST call with ResourceVersion=RV already
+				// Don't set LastSyncResourceVersionUnavailable - LIST call with ResourceVersion=RV already
 				// has a semantic that it returns data at least as fresh as provided RV.
 				// So first try to LIST with setting RV to resource version of last observed object.
 				klog.V(4).Infof("%s: watch of %v closed with: %v", r.name, r.expectedTypeName, err)
@@ -396,7 +397,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			if err != errorStopRequested {
 				switch {
 				case isExpiredError(err):
-					// Don't set LastSyncResourceVersionExpired - LIST call with ResourceVersion=RV already
+					// Don't set LastSyncResourceVersionUnavailable - LIST call with ResourceVersion=RV already
 					// has a semantic that it returns data at least as fresh as provided RV.
 					// So first try to LIST with setting RV to resource version of last observed object.
 					klog.V(4).Infof("%s: watch of %v closed with: %v", r.name, r.expectedTypeName, err)
@@ -519,9 +520,9 @@ func (r *Reflector) relistResourceVersion() string {
 	r.lastSyncResourceVersionMutex.RLock()
 	defer r.lastSyncResourceVersionMutex.RUnlock()
 
-	if r.isLastSyncResourceVersionGone {
+	if r.isLastSyncResourceVersionUnavailable {
 		// Since this reflector makes paginated list requests, and all paginated list requests skip the watch cache
-		// if the lastSyncResourceVersion is expired, we set ResourceVersion="" and list again to re-establish reflector
+		// if the lastSyncResourceVersion is unavailable, we set ResourceVersion="" and list again to re-establish reflector
 		// to the latest available ResourceVersion, using a consistent read from etcd.
 		return ""
 	}
@@ -533,12 +534,12 @@ func (r *Reflector) relistResourceVersion() string {
 	return r.lastSyncResourceVersion
 }
 
-// setIsLastSyncResourceVersionExpired sets if the last list or watch request with lastSyncResourceVersion returned a
-// expired error: HTTP 410 (Gone) Status Code.
-func (r *Reflector) setIsLastSyncResourceVersionExpired(isExpired bool) {
+// setIsLastSyncResourceVersionUnavailable sets if the last list or watch request with lastSyncResourceVersion returned
+// "expired" or "too large resource version" error.
+func (r *Reflector) setIsLastSyncResourceVersionUnavailable(isUnavailable bool) {
 	r.lastSyncResourceVersionMutex.Lock()
 	defer r.lastSyncResourceVersionMutex.Unlock()
-	r.isLastSyncResourceVersionGone = isExpired
+	r.isLastSyncResourceVersionUnavailable = isUnavailable
 }
 
 func isExpiredError(err error) bool {
@@ -547,4 +548,8 @@ func isExpiredError(err error) bool {
 	// and always returns apierrors.StatusReasonExpired. For backward compatibility we can only remove the apierrors.IsGone
 	// check when we fully drop support for Kubernetes 1.17 servers from reflectors.
 	return apierrors.IsResourceExpired(err) || apierrors.IsGone(err)
+}
+
+func isTooLargeResourceVersionError(err error) bool {
+	return apierrors.HasStatusCause(err, metav1.CauseTypeResourceVersionTooLarge)
 }


### PR DESCRIPTION
two patches taken from openshift/kubernetes are needed to fix this error 
commit: 3704174f95c7311e025284ef30bb56945fa6e7cc
commit: e21e490535fb7a5abd2f6f2c03a11613767e4800