### PR TITLE
Bug 1897073: Don't throw an error for control plane VNID

### DIFF
--- a/pkg/network/master/vnids.go
+++ b/pkg/network/master/vnids.go
@@ -80,7 +80,7 @@ func (vmap *masterVNIDMap) isAdminNamespace(nsName string) bool {
 
 func (vmap *masterVNIDMap) markAllocatedNetID(netid uint32) error {
 	// Skip GlobalVNID, not part of netID allocation range
-	if netid == network.GlobalVNID {
+	if netid < network.MinVNID {
 		return nil
 	}
 

--- a/pkg/network/netid.go
+++ b/pkg/network/netid.go
@@ -3,8 +3,9 @@ package network
 const (
 	// Maximum VXLAN Virtual Network Identifier(VNID) as per RFC#7348
 	MaxVNID = uint32((1 << 24) - 1)
-	// VNID: 1 to 9 are internally reserved for any special cases in the future
+	// VNID: 2 to 9 are internally reserved for any special cases in the future
 	MinVNID = uint32(10)
 	// VNID: 0 reserved for default namespace and can reach any network in the cluster
 	GlobalVNID = uint32(0)
+	// VNID: 1 reserved for control plane namespaces that need to reach each other in multitenant
 )


### PR DESCRIPTION
Initially VNIDs 1-9 were forbidden, in OpenShift 4 we need the control
plane components to communicate with each other, so we assigned netid 1 to
it. This is logging an error incorrectly.