### PR TITLE
Bug 1905761: Fix IP list for empty Egress network policy

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -71,8 +71,9 @@ type npPolicy struct {
 	watchesAllPods    bool
 	watchesOwnPods    bool
 
-	flows       []string
-	selectedIPs []string
+	flows         []string
+	selectedIPs   []string
+	selectsAllIPs bool
 }
 
 // npCacheEntry caches information about matches for a LabelSelector
@@ -303,7 +304,7 @@ func (np *networkPolicyPlugin) generateNamespaceFlows(otx ovs.Transaction, npns 
 			for _, flow := range npp.flows {
 				otx.AddFlow("table=80, priority=150, reg1=%d, %s actions=output:NXM_NX_REG2[]", npns.vnid, flow)
 			}
-			if npp.selectedIPs == nil {
+			if npp.selectsAllIPs {
 				allPodsSelected = true
 			}
 		}
@@ -493,7 +494,8 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 		// The rest of this function assumes that all policies affect ingress: a
 		// policy that only affects egress is, for our purposes, equivalent to one
 		// that affects ingress but does not select any pods.
-		npp.selectedIPs = []string{""}
+		npp.selectedIPs = nil
+		npp.selectsAllIPs = true
 		return npp
 	}
 
@@ -506,6 +508,7 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 		}
 	} else {
 		npp.selectedIPs = nil
+		npp.selectsAllIPs = true
 		destFlows = []string{""}
 	}
 
@@ -610,7 +613,7 @@ func (np *networkPolicyPlugin) updateNetworkPolicy(npns *npNamespace, policy *ne
 	oldNPP, existed := npns.policies[policy.UID]
 	npns.policies[policy.UID] = npp
 
-	changed := !existed || !reflect.DeepEqual(oldNPP.flows, npp.flows) || !reflect.DeepEqual(oldNPP.selectedIPs, npp.selectedIPs)
+	changed := !existed || !reflect.DeepEqual(oldNPP.flows, npp.flows) || !reflect.DeepEqual(oldNPP.selectedIPs, npp.selectedIPs) || oldNPP.selectsAllIPs != npp.selectsAllIPs
 	if !changed {
 		klog.V(5).Infof("NetworkPolicy %s/%s is unchanged", policy.Namespace, policy.Name)
 	}


### PR DESCRIPTION
For a policy with only Egress Type, the selectedIPs was being
set to an empty IP address. This resulted in attempting to program
a rule in OVS with an empty IP, resulting in an error programming
the flow(s)

Signed-off-by: vpickard <vpickard@redhat.com>