### PR TITLE
Only call ipam release in case of true allocation.

### DIFF
--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -483,6 +483,7 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 	if podIP == nil {
 		ipamResult, podIP, err = m.ipamAdd(req.Netns, req.SandboxID)
 		if err != nil {
+			success = true
 			return nil, nil, fmt.Errorf("failed to run IPAM for %v: %v", req.SandboxID, err)
 		}
 		if err := maybeAddMacvlan(v1Pod, req.Netns); err != nil {


### PR DESCRIPTION
If IPAM allocation fails, the code would have still called ipamDel.
This change tracks if the allocation was truly done or not and only
calls delete in case ipamAdd succeeds.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>