### PR TITLE
Bug 1905761: Fix empty egress policy connectivity

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -499,7 +499,7 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 		// policy that only affects egress is, for our purposes, equivalent to one
 		// that affects ingress but does not select any pods.
 		npp.selectedIPs = nil
-		npp.selectsAllIPs = true
+		npp.selectsAllIPs = false
 		return npp
 	}
 


### PR DESCRIPTION

When an empty egress policy is created, we still need to have connectivity
between pods. Add an empty flow so that the table 80 flow will be added.

Signed-off-by: vpickard <vpickard@redhat.com>