### PR TITLE
Bug 1914284: Don't try to generate NetworkPolicy flows for non-pod-network pods

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -432,7 +432,9 @@ func (np *networkPolicyPlugin) selectPodsFromNamespaces(nsLabelSel, podLabelSel 
 			continue
 		}
 		for _, pod := range pods {
-			peerFlows = append(peerFlows, fmt.Sprintf("reg0=%d, ip, nw_src=%s, ", vnid, pod.Status.PodIP))
+			if isOnPodNetwork(pod) {
+				peerFlows = append(peerFlows, fmt.Sprintf("reg0=%d, ip, nw_src=%s, ", vnid, pod.Status.PodIP))
+			}
 		}
 	}
 
@@ -471,7 +473,9 @@ func (np *networkPolicyPlugin) selectPods(npns *npNamespace, lsel *metav1.LabelS
 		return ips
 	}
 	for _, pod := range pods {
-		ips = append(ips, pod.Status.PodIP)
+		if isOnPodNetwork(pod) {
+			ips = append(ips, pod.Status.PodIP)
+		}
 	}
 	return ips
 }
@@ -674,16 +678,18 @@ func (np *networkPolicyPlugin) watchPods() {
 	np.node.kubeInformers.Core().V1().Pods().Informer().AddEventHandler(funcs)
 }
 
+func isOnPodNetwork(pod *corev1.Pod) bool {
+	if pod.Spec.HostNetwork {
+		return false
+	}
+	return pod.Status.PodIP != ""
+}
+
 func (np *networkPolicyPlugin) handleAddOrUpdatePod(obj, old interface{}, eventType watch.EventType) {
 	pod := obj.(*corev1.Pod)
 	klog.V(5).Infof("Watch %s event for Pod %q", eventType, getPodFullName(pod))
 
-	// Ignore pods with HostNetwork=true, SDN is not involved in this case
-	if pod.Spec.SecurityContext != nil && pod.Spec.HostNetwork {
-		return
-	}
-	if pod.Status.PodIP == "" {
-		klog.V(5).Infof("PodIP is not set for pod %q; ignoring", getPodFullName(pod))
+	if !isOnPodNetwork(pod) {
 		return
 	}
 


### PR DESCRIPTION
When switching from our pod cache to the informer's, we forgot to filter out the pods that would have been filtered out before. In particular, we forgot to filter out pods that didn't have an IP address assigned yet, causing us to generate invalid flows like

> `flow add table=80, priority=150, reg1=8083932, ip, nw_dst=10.128.2.8, reg0=8083932, ip, nw_src=, tcp, tp_dst=2181,  actions=output:NXM_NX_REG2[]`

(note empty `nw_src=`)

/assign @squeed 
