### PR TITLE
Bug 1915027: Fix MCS-blocking iptables rules

### DIFF
--- a/cmd/sdn-cni-plugin/openshift-sdn_linux.go
+++ b/cmd/sdn-cni-plugin/openshift-sdn_linux.go
@@ -121,10 +121,10 @@ func (p *cniPlugin) testCmdAdd(args *skel.CmdArgs) (types.Result, error) {
 
 var iptablesCommands = [][]string{
 	// Block MCS
-	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
-	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
-	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
-	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
+	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22623", "--syn", "-j", "REJECT"},
+	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "22624", "--syn", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22623", "--syn", "-j", "REJECT"},
+	{"-A", "FORWARD", "-p", "tcp", "-m", "tcp", "--dport", "22624", "--syn", "-j", "REJECT"},
 
 	// Block cloud provider metadata IP except DNS
 	{"-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "-d", "169.254.169.254", "!", "--dport", "53", "-j", "REJECT"},

--- a/pkg/network/node/iptables.go
+++ b/pkg/network/node/iptables.go
@@ -209,8 +209,8 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 			srcChain: "OUTPUT",
 			srcRule:  []string{"-m", "comment", "--comment", "firewall overrides"},
 			rules: [][]string{
-				{"-p", "tcp", "-m", "tcp", "--dport", "22623", "-j", "REJECT"},
-				{"-p", "tcp", "-m", "tcp", "--dport", "22624", "-j", "REJECT"},
+				{"-p", "tcp", "-m", "tcp", "--dport", "22623", "--syn", "-j", "REJECT"},
+				{"-p", "tcp", "-m", "tcp", "--dport", "22624", "--syn", "-j", "REJECT"},
 			},
 		},
 		Chain{


### PR DESCRIPTION
The MCS-blocking rules were too aggressive, and would block connections using 22623/22624 as a source port in some cases.

`--syn` means "SYN and not ACK", so this should make it only block attempts to establish connections to port 22623/4, and not any other traffic involving those ports.

/assign @dcbw
