### PR TITLE
Bug 1850060: Make DNS queries for egress network policy async

### DIFF
--- a/pkg/network/common/dns.go
+++ b/pkg/network/common/dns.go
@@ -35,6 +35,16 @@ type dnsValue struct {
 	updating bool
 }
 
+type DNSInterface interface {
+	Add(dns string) error
+	Size() int
+	Get(dns string) dnsValue
+	Delete(dns string)
+	SetUpdating(dns string) error
+	Update(dns string) (bool, error)
+	GetNextQueryTime() (time.Time, string, bool)
+}
+
 type DNS struct {
 	// Protects dnsMap operations
 	lock sync.Mutex

--- a/pkg/network/common/dns_test.go
+++ b/pkg/network/common/dns_test.go
@@ -464,7 +464,7 @@ func TestUpdateDNS(t *testing.T) {
 		dns.HandleFunc(test.domainName, serverFn)
 		defer dns.HandleRemove(test.domainName)
 
-		_, err = n.updateOne(test.domainName)
+		_, err = n.Update(test.domainName)
 		if test.expectFailure && err == nil {
 			t.Fatalf("Test case: %s failed, expected failure but got success", test.testCase)
 		} else if !test.expectFailure && err != nil {

--- a/pkg/network/common/egress_dns_test.go
+++ b/pkg/network/common/egress_dns_test.go
@@ -1,0 +1,123 @@
+package common
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	networkv1 "github.com/openshift/api/network/v1"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type delayedDNSTest struct {
+	name  string
+	ips   [][]net.IP
+	delay time.Duration
+}
+
+func newEgressNetworkPolicy(dnsName string, namespace string) networkv1.EgressNetworkPolicy {
+	return networkv1.EgressNetworkPolicy{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "enp",
+			Namespace: namespace,
+			UID:       ktypes.UID(namespace + "-enp"),
+		},
+		Spec: networkv1.EgressNetworkPolicySpec{
+			Egress: []networkv1.EgressNetworkPolicyRule{
+				{
+					Type: networkv1.EgressNetworkPolicyRuleAllow,
+					To: networkv1.EgressNetworkPolicyPeer{
+						DNSName: dnsName,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestSync(t *testing.T) {
+
+	startTime := time.Now().Add(150 * time.Millisecond)
+	DNSReplies := []fakeDNSReply{
+		{
+			name:          "domain1.com",
+			ttl:           1 * time.Second,
+			ips:           []net.IP{net.ParseIP("1.1.1.1")},
+			delay:         50 * time.Millisecond,
+			nextQueryTime: startTime.Add(100 * time.Millisecond),
+		},
+		{
+			name:          "domain2.com",
+			ttl:           1 * time.Second,
+			ips:           []net.IP{net.ParseIP("1.2.3.4")},
+			delay:         3500 * time.Millisecond,
+			nextQueryTime: startTime.Add(150 * time.Millisecond),
+		},
+		{
+			name:          "domain1.com",
+			ttl:           1 * time.Second,
+			ips:           []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("1.1.1.2")},
+			delay:         50 * time.Millisecond,
+			nextQueryTime: startTime.Add(200 * time.Millisecond),
+		},
+	}
+
+	dnsInfo := NewFakeDNS(DNSReplies)
+	egressDNS := EgressDNS{
+		dns:                dnsInfo,
+		dnsNamesToPolicies: map[string]sets.String{},
+		namespaces:         map[ktypes.UID]string{},
+		added:              make(chan bool),
+		Updates:            make(chan EgressDNSUpdates),
+		dnsResponse:        make(chan DNSResponseNotification),
+		stopCh:             make(chan struct{}),
+	}
+
+	egressDNS.Add(newEgressNetworkPolicy("domain1.com", "fake-ns-1"))
+	egressDNS.Add(newEgressNetworkPolicy("domain2.com", "fake-ns-2"))
+	egressDNS.Add(newEgressNetworkPolicy("domain1.com", "fake-ns-3"))
+
+	go egressDNS.Sync()
+	update := <-egressDNS.Updates
+	if len(update) != 2 {
+		t.Errorf("Expected exactly two elements in the update: %v", update)
+		// Exit the function to avoid a nil pointer dereference
+		return
+	}
+
+	u0 := update[0]
+	u1 := update[1]
+	if !((u0.Namespace == "fake-ns-1" && u1.Namespace == "fake-ns-3") ||
+		(u0.Namespace == "fake-ns-3" && u1.Namespace == "fake-ns-1")) {
+		t.Errorf("Expecting an update for fake-ns-1 and fake-ns-3. Got: %v", update)
+	}
+
+	update = <-egressDNS.Updates
+	if len(update) != 2 {
+		t.Errorf("Expected exactly two elements in the update: %v", update)
+		// Exit the function to avoid a nil pointer dereference
+		return
+	}
+
+	u0 = update[0]
+	u1 = update[1]
+	if !((u0.Namespace == "fake-ns-1" && u1.Namespace == "fake-ns-3") ||
+		(u0.Namespace == "fake-ns-3" && u1.Namespace == "fake-ns-1")) {
+		t.Errorf("Expecting an update for fake-ns-1 and fake-ns-3. Got: %v", update)
+	}
+
+	update = <-egressDNS.Updates
+	if len(update) != 1 {
+		t.Errorf("Expected exactly one element in the update: %v", update)
+		// Exit the function to avoid a nil pointer dereference
+		return
+	}
+	u0 = update[0]
+	if u0.Namespace != "fake-ns-2" {
+		t.Errorf("Expecting an update for fake-ns-2. Got: %v", update)
+	}
+	egressDNS.Stop()
+}

--- a/pkg/network/common/fake_dns.go
+++ b/pkg/network/common/fake_dns.go
@@ -1,0 +1,93 @@
+package common
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+type fakeDNSReply struct {
+	name string
+	ips  []net.IP
+	// ttl is *not* honored, we need something for get
+	ttl time.Duration
+
+	hasBeenUpdated bool
+
+	nextQueryTime time.Time
+	delay         time.Duration
+}
+
+type FakeDNS struct {
+
+	// Protects dnsReplies operations
+	lock sync.Mutex
+	// Holds DNS name and its corresponding information
+	dnsReplies []fakeDNSReply
+}
+
+func NewFakeDNS(dnsReplies []fakeDNSReply) *FakeDNS {
+	return &FakeDNS{
+		dnsReplies: dnsReplies,
+	}
+}
+
+// Add: Not implemented
+func (f *FakeDNS) Add(dns string) error {
+	return nil
+}
+
+func (f *FakeDNS) Size() int {
+	return 0
+}
+
+func (f *FakeDNS) Get(dns string) dnsValue {
+	data := dnsValue{}
+	return data
+}
+func (f *FakeDNS) Delete(dns string) {
+
+}
+func (f *FakeDNS) SetUpdating(dns string) error {
+	return nil
+}
+
+// Update always assumes that if there is a reply the IP list always changes
+func (f *FakeDNS) Update(dns string) (bool, error) {
+	f.lock.Lock()
+	delay := 0 * time.Second
+	changed := false
+	for i := range f.dnsReplies {
+		if f.dnsReplies[i].name != dns {
+			continue
+		}
+		if !f.dnsReplies[i].hasBeenUpdated {
+			f.dnsReplies[i].hasBeenUpdated = true
+			delay = f.dnsReplies[i].delay
+			changed = true
+			break
+		}
+	}
+	f.lock.Unlock()
+	time.Sleep(delay)
+	return changed, nil
+}
+
+func (f *FakeDNS) GetNextQueryTime() (time.Time, string, bool) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	timeSet := false
+	var minTime time.Time
+	var dns string
+
+	for i := range f.dnsReplies {
+		if !f.dnsReplies[i].hasBeenUpdated {
+			timeSet = true
+			dns = f.dnsReplies[i].name
+			minTime = f.dnsReplies[i].nextQueryTime
+			return minTime, dns, timeSet
+		}
+	}
+
+	return minTime, dns, timeSet
+}


### PR DESCRIPTION
Prior to this PR we have exactly one goroutine to query all the DNS names synchronously.
If a DNS query is slow we'll block the whole synchronization goroutine causing the IP addresses of flows for the rest of the dnsNames to be potentially outdated.