### PR TITLE
Bug 1919737: Prefer local endpoint for cluster DNS service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ replace (
 	k8s.io/kube-scheduler => github.com/openshift/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20201204013253-b878d08e764d
 	k8s.io/kubectl => github.com/openshift/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20201204013253-b878d08e764d
 	k8s.io/kubelet => github.com/openshift/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20201204013253-b878d08e764d
-	k8s.io/kubernetes => github.com/openshift/kubernetes v1.20.0-beta.2.0.20201204013253-b878d08e764d
+	k8s.io/kubernetes => github.com/openshift/kubernetes v1.20.0-beta.2.0.20210218204625-8365549d4155
 	k8s.io/legacy-cloud-providers => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20201204013253-b878d08e764d
 	k8s.io/metrics => github.com/openshift/kubernetes/staging/src/k8s.io/metrics v0.0.0-20201204013253-b878d08e764d
 	k8s.io/mount-utils => github.com/openshift/kubernetes/staging/src/k8s.io/mount-utils v0.0.0-20201204013253-b878d08e764d

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70 h1:LvJxSt/lnLT
 github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70/go.mod h1:HeCrq1LSOBgHAUpINH4IgBLkt2U/NBwE5sq4JJgcl2Y=
 github.com/openshift/golang-glog v0.0.0-20190322123450-3c92600d7533 h1:A5VovyRu3JFIPmC20HHrsOOny0PIdHuzDdNMULru48k=
 github.com/openshift/golang-glog v0.0.0-20190322123450-3c92600d7533/go.mod h1:3sa6LKKRDnR1xy4Kn8htvPwqIOVwXh8fIU3LRY22q3U=
-github.com/openshift/kubernetes v1.20.0-beta.2.0.20201204013253-b878d08e764d h1:+xV76Bk0M9cTil6+jEddNB3f5XJnFMOrIsfV5en+bUI=
-github.com/openshift/kubernetes v1.20.0-beta.2.0.20201204013253-b878d08e764d/go.mod h1:/xrHGNfoQphtkhZvyd5bA1lRmz+QkDVmBZu+O8QMoek=
+github.com/openshift/kubernetes v1.20.0-beta.2.0.20210218204625-8365549d4155 h1:acz8ZWk541TBV2rLzz8EdFZVmb3wIdzc53+BAWG8xo0=
+github.com/openshift/kubernetes v1.20.0-beta.2.0.20210218204625-8365549d4155/go.mod h1:/xrHGNfoQphtkhZvyd5bA1lRmz+QkDVmBZu+O8QMoek=
 github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20201204013253-b878d08e764d h1:VvYzIbDnA9qUPEOGdqhYa7V5+ciSAsexDtR8vfHSTKQ=
 github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20201204013253-b878d08e764d/go.mod h1:WITCNA3qJC44dfLg1s/kdEQ51akGrwqOKkMnN7XoKXE=
 github.com/openshift/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20201204013253-b878d08e764d/go.mod h1:A5mDfmENvCI0QodhAc0ipXV1aI5JUiZoJkA7BvHs9EQ=

--- a/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
@@ -1029,6 +1029,20 @@ func (proxier *Proxier) syncProxyRules() {
 			hasEndpoints = len(allEndpoints) > 0
 		}
 
+		// Prefer local endpoint for the DNS service.
+		// Fixes <https://bugzilla.redhat.com/show_bug.cgi?id=1919737>.
+		// TODO: Delete this if-block once internal traffic policy is
+		// implemented and the DNS operator is updated to use it.
+		if svcNameString == "openshift-dns/dns-default:dns" {
+			for _, ep := range allEndpoints {
+				if ep.GetIsLocal() {
+					klog.V(4).Infof("Found a local endpoint %q for service %q; preferring the local endpoint and ignoring %d other endpoints", ep.String(), svcNameString, len(allEndpoints) - 1)
+					allEndpoints = []proxy.Endpoint{ep}
+					break
+				}
+			}
+		}
+
 		svcChain := svcInfo.servicePortChainName
 		if hasEndpoints {
 			// Create the per-service chain, retaining counters if possible.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -927,7 +927,7 @@ k8s.io/kubectl/pkg/util/openapi/validation
 k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
-# k8s.io/kubernetes v1.20.0-rc.0 => github.com/openshift/kubernetes v1.20.0-beta.2.0.20201204013253-b878d08e764d
+# k8s.io/kubernetes v1.20.0-rc.0 => github.com/openshift/kubernetes v1.20.0-beta.2.0.20210218204625-8365549d4155
 k8s.io/kubernetes/cmd/kube-proxy
 k8s.io/kubernetes/cmd/kube-proxy/app
 k8s.io/kubernetes/pkg/api/legacyscheme


### PR DESCRIPTION
* `go.mod`: Bump github.com/openshift/kubernetes.
* `go.sum`:
* `vendor/modules.txt`: Regenerate.
* `vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go` (`syncProxyRules`): Prefer a local endpoint for the cluster DNS service.
