### PR TITLE
[release-4.6] Bug 1928773: Prefer local endpoint for cluster DNS service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ replace (
 	k8s.io/kube-scheduler => github.com/openshift/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20200924180536-c77dd9b79070
 	k8s.io/kubectl => github.com/openshift/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20200924180536-c77dd9b79070
 	k8s.io/kubelet => github.com/openshift/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20200924180536-c77dd9b79070
-	k8s.io/kubernetes => github.com/openshift/kubernetes v0.0.0-20200924180536-c77dd9b79070
+	k8s.io/kubernetes => github.com/openshift/kubernetes v1.19.0-alpha.0.0.20210302151112-05e619e27cf6
 	k8s.io/legacy-cloud-providers => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200924180536-c77dd9b79070
 	k8s.io/metrics => github.com/openshift/kubernetes/staging/src/k8s.io/metrics v0.0.0-20200924180536-c77dd9b79070
 	k8s.io/sample-apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20200924180536-c77dd9b79070

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,8 @@ github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70 h1:LvJxSt/lnLT
 github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70/go.mod h1:HeCrq1LSOBgHAUpINH4IgBLkt2U/NBwE5sq4JJgcl2Y=
 github.com/openshift/golang-glog v0.0.0-20190322123450-3c92600d7533 h1:A5VovyRu3JFIPmC20HHrsOOny0PIdHuzDdNMULru48k=
 github.com/openshift/golang-glog v0.0.0-20190322123450-3c92600d7533/go.mod h1:3sa6LKKRDnR1xy4Kn8htvPwqIOVwXh8fIU3LRY22q3U=
-github.com/openshift/kubernetes v0.0.0-20200924180536-c77dd9b79070 h1:8xP8anx0ib8cRHAYs9DJdN7rj4lUmOYFaJYGicT/fKo=
-github.com/openshift/kubernetes v0.0.0-20200924180536-c77dd9b79070/go.mod h1:Efg82S+Ti02A/Mww53bxroc7IgzX2bgPsf6hT8gAs3M=
+github.com/openshift/kubernetes v1.19.0-alpha.0.0.20210302151112-05e619e27cf6 h1:U2kFgbhCu5pgBaca7Ecm2TVEhHcYmFGkICITyQZ5cBk=
+github.com/openshift/kubernetes v1.19.0-alpha.0.0.20210302151112-05e619e27cf6/go.mod h1:Efg82S+Ti02A/Mww53bxroc7IgzX2bgPsf6hT8gAs3M=
 github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20200924180536-c77dd9b79070 h1:twp4f4xBdg4yTYWYHj9McT4pIk5gbj1/j5VHF8yx7XQ=
 github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20200924180536-c77dd9b79070/go.mod h1:oMzWB6/RPBLYAObltLVSu5Ms1ZztBe7G8s1ni2rZY7w=
 github.com/openshift/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20200924180536-c77dd9b79070/go.mod h1:BVIYewlEVCukQBRrZR3Kms8GdCsDQBsRIBCoy3rwzMk=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -842,7 +842,7 @@ k8s.io/kubectl/pkg/util/openapi/validation
 k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
-# k8s.io/kubernetes v1.18.6 => github.com/openshift/kubernetes v0.0.0-20200924180536-c77dd9b79070
+# k8s.io/kubernetes v1.18.6 => github.com/openshift/kubernetes v1.19.0-alpha.0.0.20210302151112-05e619e27cf6
 k8s.io/kubernetes/cmd/kube-proxy
 k8s.io/kubernetes/cmd/kube-proxy/app
 k8s.io/kubernetes/pkg/api/legacyscheme


### PR DESCRIPTION
Bump the vendored github.com/openshift/kubernetes to pick up https://github.com/openshift/kubernetes/pull/581/commits/3a5282591456b301781c98a60a2bffaf265ed6c0: "UPSTREAM: &lt;carry&gt;: Prefer local endpoint for cluster DNS service".

This bump incidentally picks up commit https://github.com/openshift/kubernetes/commit/6d9f2fe774e6ad19a8c538c76610f3277d05f30f: "UPSTREAM: 95252: Kube-proxy: Perf-fix: Shrink INPUT chain".

* `go.mod`: Bump github.com/openshift/kubernetes.
* `go.sum`:
* `vendor/modules.txt`: Regenerate.
* `vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go`: Bump.