### PR TITLE
Bug 1935297: Prefer local endpoint for cluster DNS service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ replace (
 	k8s.io/kube-scheduler => github.com/openshift/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20200506150957-662762e23e80
 	k8s.io/kubectl => github.com/openshift/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20200506150957-662762e23e80
 	k8s.io/kubelet => github.com/openshift/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20200506150957-662762e23e80
-	k8s.io/kubernetes => github.com/openshift/kubernetes v0.0.0-20200506150957-662762e23e80
+	k8s.io/kubernetes => github.com/openshift/kubernetes v1.19.0-alpha.0.0.20210304151414-a18cff1620e7
 	k8s.io/legacy-cloud-providers => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20200506150957-662762e23e80
 	k8s.io/metrics => github.com/openshift/kubernetes/staging/src/k8s.io/metrics v0.0.0-20200506150957-662762e23e80
 	k8s.io/sample-apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20200506150957-662762e23e80

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,8 @@ github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70 h1:LvJxSt/lnLT
 github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70/go.mod h1:HeCrq1LSOBgHAUpINH4IgBLkt2U/NBwE5sq4JJgcl2Y=
 github.com/openshift/golang-glog v0.0.0-20190322123450-3c92600d7533 h1:A5VovyRu3JFIPmC20HHrsOOny0PIdHuzDdNMULru48k=
 github.com/openshift/golang-glog v0.0.0-20190322123450-3c92600d7533/go.mod h1:3sa6LKKRDnR1xy4Kn8htvPwqIOVwXh8fIU3LRY22q3U=
-github.com/openshift/kubernetes v0.0.0-20200506150957-662762e23e80 h1:eQcuKGqiJdo66lJ9mCFGmbxGpS+XegVeeqcZorVo1fg=
-github.com/openshift/kubernetes v0.0.0-20200506150957-662762e23e80/go.mod h1:z8xjOOO1Ljz+TaHpOxVGC7cxtF32TesIamoQ+BZrVS0=
+github.com/openshift/kubernetes v1.19.0-alpha.0.0.20210304151414-a18cff1620e7 h1:ZTIS2UoizPGwFto1jXS6WRmlSH4E2c/E9XdeVQTZE28=
+github.com/openshift/kubernetes v1.19.0-alpha.0.0.20210304151414-a18cff1620e7/go.mod h1:z8xjOOO1Ljz+TaHpOxVGC7cxtF32TesIamoQ+BZrVS0=
 github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20200506150957-662762e23e80 h1:biURuD1Ca0gawSpuCUj7RE5Ql9LMWwSLzknzFNJ7al0=
 github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20200506150957-662762e23e80/go.mod h1:oMzWB6/RPBLYAObltLVSu5Ms1ZztBe7G8s1ni2rZY7w=
 github.com/openshift/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20200506150957-662762e23e80/go.mod h1:tMuEHO85+WtdJsLBJ1U4bh7oB23v/D4vP0BtL39qxM4=

--- a/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
+++ b/vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go
@@ -974,6 +974,20 @@ func (proxier *Proxier) syncProxyRules() {
 			hasEndpoints = len(allEndpoints) > 0
 		}
 
+		// Prefer local endpoint for the DNS service.
+		// Fixes <https://bugzilla.redhat.com/show_bug.cgi?id=1919737>.
+		// TODO: Delete this if-block once internal traffic policy is
+		// implemented and the DNS operator is updated to use it.
+		if svcNameString == "openshift-dns/dns-default:dns" {
+			for _, ep := range allEndpoints {
+				if ep.GetIsLocal() {
+					klog.V(4).Infof("Found a local endpoint %q for service %q; preferring the local endpoint and ignoring %d other endpoints", ep.String(), svcNameString, len(allEndpoints) - 1)
+					allEndpoints = []proxy.Endpoint{ep}
+					break
+				}
+			}
+		}
+
 		svcChain := svcInfo.servicePortChainName
 		if hasEndpoints {
 			// Create the per-service chain, retaining counters if possible.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -844,7 +844,7 @@ k8s.io/kubectl/pkg/util/openapi/validation
 k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
-# k8s.io/kubernetes v1.18.2 => github.com/openshift/kubernetes v0.0.0-20200506150957-662762e23e80
+# k8s.io/kubernetes v1.18.2 => github.com/openshift/kubernetes v1.19.0-alpha.0.0.20210304151414-a18cff1620e7
 k8s.io/kubernetes/cmd/kube-proxy
 k8s.io/kubernetes/cmd/kube-proxy/app
 k8s.io/kubernetes/pkg/api/legacyscheme


### PR DESCRIPTION
Bump the vendored github.com/openshift/kubernetes to pick up https://github.com/openshift/kubernetes/pull/604/commits/a18cff1620e79cfce7f212807f93bea87314511a: "UPSTREAM: &lt;carry&gt;: Prefer local endpoint for cluster DNS service".

* `go.mod`: Bump github.com/openshift/kubernetes.
* `go.sum`:
* `vendor/modules.txt`: Regenerate.
* `vendor/k8s.io/kubernetes/pkg/proxy/iptables/proxier.go` (`syncProxyRules`): Prefer a local endpoint for the cluster DNS service.