### PR TITLE
Bug 1910378: networkpolicy: pass traffic through NAT to handle possible tuple collisions

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -111,7 +111,10 @@ func (np *networkPolicyPlugin) Start(node *OsdnNode) error {
 
 	otx := node.oc.NewTransaction()
 	for _, cn := range np.node.networkInfo.ClusterNetworks {
-		otx.AddFlow("table=21, priority=200, ip, nw_dst=%s, actions=ct(commit,table=30)", cn.ClusterCIDR.String())
+		// Must pass packets through CT NAT to ensure NAT state is handled
+		// correctly by OVS when NAT-ed packets have tuple collisions.
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1910378
+		otx.AddFlow("table=21, priority=200, ip, nw_dst=%s, ct_state=-rpl, actions=ct(commit,nat(src=0.0.0.0),table=30)", cn.ClusterCIDR.String())
 	}
 	otx.AddFlow("table=80, priority=200, ip, ct_state=+rpl, actions=output:NXM_NX_REG2[]")
 	if err := otx.Commit(); err != nil {

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -36,7 +36,7 @@ const (
 	Vxlan0 = "vxlan0"
 
 	// rule versioning; increment each time flow rules change
-	ruleVersion = 8
+	ruleVersion = 9
 
 	ruleVersionTable = 253
 )
@@ -153,7 +153,7 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 	otx.AddFlow("table=30, priority=300, ip, nw_dst=%s, actions=output:2", localSubnetGateway)
 	otx.AddFlow("table=30, priority=100, ip, nw_dst=%s, actions=goto_table:60", serviceNetworkCIDR)
 	if oc.useConnTrack {
-		otx.AddFlow("table=30, priority=300, ip, nw_dst=%s, ct_state=+rpl, actions=ct(nat,table=70)", localSubnetCIDR)
+		otx.AddFlow("table=30, priority=250, ip, nw_dst=%s, ct_state=+rpl, actions=ct(nat,table=70)", localSubnetCIDR)
 	}
 	otx.AddFlow("table=30, priority=200, ip, nw_dst=%s, actions=goto_table:70", localSubnetCIDR)
 	for _, clusterCIDR := range clusterNetworkCIDR {


### PR DESCRIPTION
If a pod makes connections to the same destination pod via a service VIP and
directly to the pod's IP address, it may be the case that both connections
choose the same source port. After the service VIP connection is DNAT-ed to
the destination pod's IP address, both connections will have the same 4-tuple.

When conntrack processes the second connection's TCP SYN and attempts to commit
the conntrack state, the commit fails due to the tuple collision.

To prevent the commit failure, make sure SNAT is done on the source port
during the commit in case of a collision. The use of a fake "0.0.0.0"
address (an undocumented "feature" of OVS that will soon be formalized)
ensures that only the source port will be touched if necessary.

Note that the packets won't be manipulated if they don't need to be, even
though they are passed through NAT.

Flow change suggested by Eelco Chaudron and Flavio Leitner
Additional fixes by Dan Winship