### PR TITLE
Bug 1926931: Fix incorrect unmonitoring of egress nodes

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -120,7 +120,7 @@ func (eip *egressIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP string) 
 			utilruntime.HandleError(fmt.Errorf("Error assigning Egress IP %q: %v", egressIP, err))
 		}
 	} else if eip.vxlanMonitor != nil {
-		eip.vxlanMonitor.AddNode(nodeIP)
+		eip.vxlanMonitor.AddEgressIP(nodeIP, egressIP)
 	}
 }
 
@@ -132,7 +132,7 @@ func (eip *egressIPWatcher) ReleaseEgressIP(egressIP, nodeIP string) {
 			utilruntime.HandleError(fmt.Errorf("Error releasing Egress IP %q: %v", egressIP, err))
 		}
 	} else if eip.vxlanMonitor != nil {
-		eip.vxlanMonitor.RemoveNode(nodeIP)
+		eip.vxlanMonitor.RemoveEgressIP(nodeIP, egressIP)
 	}
 }
 

--- a/pkg/network/node/vxlan_monitor.go
+++ b/pkg/network/node/vxlan_monitor.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/klog/v2"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/sdn/pkg/network/common"
@@ -60,6 +61,8 @@ type egressVXLANNode struct {
 	nodeIP  string
 	offline bool
 
+	egressIPs sets.String
+
 	in  uint64
 	out uint64
 
@@ -84,35 +87,41 @@ func newEgressVXLANMonitor(ovsif ovs.Interface, tracker *common.EgressIPTracker,
 	}
 }
 
-func (evm *egressVXLANMonitor) AddNode(nodeIP string) {
+func (evm *egressVXLANMonitor) AddEgressIP(nodeIP, egressIP string) {
 	evm.Lock()
 	defer evm.Unlock()
 
 	if evm.monitorNodes[nodeIP] != nil {
+		evm.monitorNodes[nodeIP].egressIPs.Insert(egressIP)
 		return
 	}
 	klog.V(4).Infof("Monitoring node %s", nodeIP)
 
-	evm.monitorNodes[nodeIP] = &egressVXLANNode{nodeIP: nodeIP}
+	evm.monitorNodes[nodeIP] = &egressVXLANNode{
+		nodeIP:    nodeIP,
+		egressIPs: sets.NewString(egressIP),
+	}
 	if len(evm.monitorNodes) == 1 && evm.pollInterval != 0 {
 		evm.stop = make(chan struct{})
 		go utilwait.PollUntil(evm.pollInterval, evm.poll, evm.stop)
 	}
 }
 
-func (evm *egressVXLANMonitor) RemoveNode(nodeIP string) {
+func (evm *egressVXLANMonitor) RemoveEgressIP(nodeIP, egressIP string) {
 	evm.Lock()
 	defer evm.Unlock()
 
 	if evm.monitorNodes[nodeIP] == nil {
 		return
 	}
-	klog.V(4).Infof("Unmonitoring node %s", nodeIP)
-
-	delete(evm.monitorNodes, nodeIP)
-	if len(evm.monitorNodes) == 0 && evm.stop != nil {
-		close(evm.stop)
-		evm.stop = nil
+	evm.monitorNodes[nodeIP].egressIPs.Delete(egressIP)
+	if evm.monitorNodes[nodeIP].egressIPs.Len() == 0 {
+		klog.V(4).Infof("Unmonitoring node %s", nodeIP)
+		delete(evm.monitorNodes, nodeIP)
+		if len(evm.monitorNodes) == 0 && evm.stop != nil {
+			close(evm.stop)
+			evm.stop = nil
+		}
 	}
 }
 


### PR DESCRIPTION
Currently we incorrectly unmonitoring an egress node whenever
any egress IP stops referencing that node, this is incorrect
because there might be other egress IPs (defined on a separate
namespace) that stills references that egress node. Consider
the following example:

```
oc get hostsubnet
NAME                             HOST                             HOST IP          SUBNET          EGRESS CIDRS   EGRESS IPS
huirwang-45-xslwp-master-0       huirwang-45-xslwp-master-0       172.31.249.251   10.128.0.0/23
huirwang-45-xslwp-master-1       huirwang-45-xslwp-master-1       172.31.249.250   10.130.0.0/23
huirwang-45-xslwp-master-2       huirwang-45-xslwp-master-2       172.31.249.45    10.129.0.0/23                  [172.31.249.205 172.31.249.206]
huirwang-45-xslwp-worker-4hhvt   huirwang-45-xslwp-worker-4hhvt   172.31.249.182   10.131.0.0/23                  [172.31.249.203 172.31.249.204]
huirwang-45-xslwp-worker-mssqh   huirwang-45-xslwp-worker-mssqh   172.31.249.112   10.128.2.0/23

oc get netnamespace
...
test1                                                13617042   [172.31.249.203 172.31.249.205]
test2                                                14768742   [172.31.249.204 172.31.249.206]
```

If someone now decides to remove the egress IPs associated with
test2: it will lead to having both egress nodes huirwang-45-xslwp-worker-4hhvt
and huirwang-45-xslwp-master-2 unmonitored, this can be seen
in the SDN logs on the worker node hosting the workload pods
as:

```
I0310 13:00:47.380770    4220 egressip.go:411] Removing egress IP 172.31.249.206 from node 172.31.249.45
I0310 13:00:47.380828    4220 vxlan_monitor.go:110] Unmonitoring node 172.31.249.45
I0310 13:00:47.380834    4220 egressip.go:411] Removing egress IP 172.31.249.204 from node 172.31.249.182
I0310 13:00:47.380837    4220 vxlan_monitor.go:110] Unmonitoring node 172.31.249.182
```

This is however incorrect as the egress IPs in namespace test1
still has a reference to those egress nodes.

This patch fixes that.

/assign @juanluisvaladas @danwinship 