### PR TITLE
Bug 1948999: Remove check enforcing single egress IP for automatic assignment

### DIFF
--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -569,9 +569,6 @@ func (eit *EgressIPTracker) makeEmptyAllocation() (map[string][]string, map[stri
 		} else if len(eip.nodes) > 1 || len(eip.namespaces) > 1 {
 			// Erroneously allocated to multiple nodes or multiple namespaces
 			alreadyAllocated[egressIP] = true
-		} else if len(eip.namespaces) == 1 && len(eip.namespaces[0].requestedIPs) > 1 {
-			// Using multiple-egress-IP HA
-			alreadyAllocated[egressIP] = true
 		}
 	}
 


### PR DESCRIPTION
The load-balancing feature overlooked removing the check that exists
enforcing that only one egress IP is assigned in automatic assignment
mode. This patch removes that check. The concern with removing this
check is that we might have multiple egress IPs being assigned to the
same node (since any previous implementation didn't have to deal with
that). This is however covered by the verification in `egressIPActive`
which ensures that no more than one egress IP for each namespace is
assigned to every node.

FYI: I have tested this on a local setup with Kind and it works. Both the 
load-balancing feature functions with automatic assignment, and we never
assign more than one egress IP per node for each namespace.

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>

/assign @JacobTanenbaum @danwinship 