### PR TITLE
Bug 1949607: fix multiple egressIPs for a single namespace

### DIFF
--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -569,9 +569,6 @@ func (eit *EgressIPTracker) makeEmptyAllocation() (map[string][]string, map[stri
 		} else if len(eip.nodes) > 1 || len(eip.namespaces) > 1 {
 			// Erroneously allocated to multiple nodes or multiple namespaces
 			alreadyAllocated[egressIP] = true
-		} else if len(eip.namespaces) == 1 && len(eip.namespaces[0].requestedIPs) > 1 {
-			// Using multiple-egress-IP HA
-			alreadyAllocated[egressIP] = true
 		}
 	}
 

--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	ktypes "k8s.io/apimachinery/pkg/types"
 
@@ -1088,10 +1089,16 @@ func TestEgressCIDRAllocation(t *testing.T) {
 
 	allocation = eit.ReallocateEgressIPs()
 	updateAllocations(eit, allocation)
+	time.Sleep(10 * time.Second)
 	err = w.assertChanges(
-		"release 172.17.0.102 on 172.17.0.4",
-		"namespace 45 dropped",
-		"update egress CIDRs",
+		"claim 172.17.1.102 on 172.17.0.3 for namespace 45",
+		"claim 172.17.1.109 on 172.17.0.3 for namespace 49",
+		"namespace 45 via 172.17.0.102 on 172.17.0.4",
+		"namespace 45 via 172.17.1.102 on 172.17.0.3",
+		"namespace 49 via 172.17.1.109 on 172.17.0.3",
+		"claim 172.17.0.109 on 172.17.0.4 for namespace 49",
+		"namespace 49 via 172.17.0.109 on 172.17.0.4",
+		"namespace 49 via 172.17.1.109 on 172.17.0.3",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)


### PR DESCRIPTION
Leaving the check there causes openshift-sdn to treat multiple
egressIPs assigned to a single namespace as already allocated