### PR TITLE
Bug 1952079: Don't require EndpointSlice to be disabled

### DIFF
--- a/pkg/openshift-sdn/proxy.go
+++ b/pkg/openshift-sdn/proxy.go
@@ -67,9 +67,8 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		return
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice) ||
-		utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceProxying) {
-		klog.Warningf("kube-proxy has unsupported EndpointSlice/EndpointSliceProxying gates enabled")
+	if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSliceProxying) {
+		klog.Warningf("kube-proxy has unsupported EndpointSliceProxying gates enabled")
 		close(waitChan)
 		return
 	}


### PR DESCRIPTION
It can't be disabled in 1.21, and it doesn't matter anyway; it's EndpointSliceProxying that controls whether kube-proxy uses slices.