### PR TITLE
generalize the polling of `monitorNodes` between node and master

### DIFF
--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	v1 "k8s.io/api/core/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -19,6 +20,7 @@ import (
 
 	networkv1 "github.com/openshift/api/network/v1"
 	networkinformers "github.com/openshift/client-go/network/informers/externalversions/network/v1"
+	kcoreinformers "k8s.io/client-go/informers/core/v1"
 )
 
 type NodeEgress struct {
@@ -30,7 +32,9 @@ type NodeEgress struct {
 	requestedCIDRs sets.String
 	parsedCIDRs    map[string]*net.IPNet
 
-	offline bool
+	activeEgressIPs sets.String
+	offline         bool
+	retries         int
 }
 
 type namespaceEgress struct {
@@ -60,7 +64,7 @@ type egressIPInfo struct {
 type EgressIPWatcher interface {
 	Synced()
 
-	ClaimEgressIP(vnid uint32, egressIP, nodeIP string)
+	ClaimEgressIP(vnid uint32, egressIP, nodeIP, nodeName string)
 	ReleaseEgressIP(egressIP, nodeIP string)
 
 	SetNamespaceEgressNormal(vnid uint32)
@@ -75,11 +79,14 @@ type EgressIPTracker struct {
 
 	watcher EgressIPWatcher
 
+	nodeInformer     kcoreinformers.NodeInformer
 	nodes            map[ktypes.UID]*NodeEgress
 	nodesByNodeIP    map[string]*NodeEgress
 	namespacesByVNID map[uint32]*namespaceEgress
 	egressIPs        map[string]*egressIPInfo
 	nodesWithCIDRs   int
+	monitorNodes     sync.Map
+	stop             chan struct{}
 
 	changedEgressIPs  map[*egressIPInfo]bool
 	changedNamespaces map[*namespaceEgress]bool
@@ -94,20 +101,23 @@ func NewEgressIPTracker(watcher EgressIPWatcher) *EgressIPTracker {
 		nodesByNodeIP:    make(map[string]*NodeEgress),
 		namespacesByVNID: make(map[uint32]*namespaceEgress),
 		egressIPs:        make(map[string]*egressIPInfo),
+		monitorNodes:     sync.Map{},
 
 		changedEgressIPs:  make(map[*egressIPInfo]bool),
 		changedNamespaces: make(map[*namespaceEgress]bool),
 	}
 }
 
-func (eit *EgressIPTracker) Start(hostSubnetInformer networkinformers.HostSubnetInformer, netNamespaceInformer networkinformers.NetNamespaceInformer) {
+func (eit *EgressIPTracker) Start(hostSubnetInformer networkinformers.HostSubnetInformer, netNamespaceInformer networkinformers.NetNamespaceInformer, nodeInformer kcoreinformers.NodeInformer) {
 	eit.watchHostSubnets(hostSubnetInformer)
 	eit.watchNetNamespaces(netNamespaceInformer)
+	eit.nodeInformer = nodeInformer
 
 	go func() {
 		cache.WaitForCacheSync(utilwait.NeverStop,
 			hostSubnetInformer.Informer().HasSynced,
-			netNamespaceInformer.Informer().HasSynced)
+			netNamespaceInformer.Informer().HasSynced,
+			nodeInformer.Informer().HasSynced)
 
 		eit.Lock()
 		defer eit.Unlock()
@@ -290,6 +300,174 @@ func (eit *EgressIPTracker) UpdateHostSubnetEgress(hs *networkv1.HostSubnet) {
 	eit.syncEgressIPs()
 }
 
+func nodeIsReady(node *v1.Node) bool {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == v1.NodeReady {
+			if cond.Status == v1.ConditionFalse || cond.Status == v1.ConditionUnknown {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// SetMonitorNodes updates EgressIPTracker with the node data provided and
+// starts a go-routine (if one is not already running) which polls monitorNodes
+// to check if they are ready and reachable.
+func (eit *EgressIPTracker) SetMonitorNodes(monitorNodes []*NodeEgress) {
+	for _, node := range monitorNodes {
+		if _, exists := eit.monitorNodes.Load(node.NodeIP); !exists {
+			eit.monitorNodes.Store(node.NodeIP, node)
+		}
+	}
+	eit.monitorNodes.Range(func(key, value interface{}) bool {
+		nodeIP := key.(string)
+		found := false
+		for _, node := range monitorNodes {
+			if node.NodeIP == nodeIP {
+				found = true
+			}
+		}
+		if !found {
+			eit.monitorNodes.Delete(nodeIP)
+		}
+		return true
+	})
+	if eit.getMonitorNodesLen() > 0 {
+		if eit.stop == nil {
+			eit.stop = make(chan struct{})
+			go utilwait.PollUntil(defaultPollInterval, eit.poll, eit.stop)
+		}
+	} else {
+		if eit.stop != nil {
+			close(eit.stop)
+			eit.stop = nil
+		}
+	}
+}
+
+// AddEgressIP starts a go-routine (if one is not already running) which polls
+// monitorNodes to check if they are ready and reachable
+func (eit *EgressIPTracker) AddEgressIP(nodeIP, nodeName, egressIP string) {
+	if nodeIntf, exists := eit.monitorNodes.Load(nodeIP); exists {
+		node := nodeIntf.(*NodeEgress)
+		node.activeEgressIPs.Insert(egressIP)
+		return
+	}
+	klog.V(4).Infof("Monitoring node %s", nodeIP)
+	eit.monitorNodes.Store(nodeIP, &NodeEgress{
+		NodeIP:          nodeIP,
+		activeEgressIPs: sets.NewString(egressIP),
+		NodeName:        nodeName,
+	})
+	if eit.getMonitorNodesLen() == 1 && eit.stop == nil {
+		eit.stop = make(chan struct{})
+		go utilwait.PollUntil(defaultPollInterval, eit.poll, eit.stop)
+	}
+}
+
+func (eit *EgressIPTracker) getMonitorNodesLen() int {
+	res := 0
+	eit.monitorNodes.Range(func(key, value interface{}) bool {
+		res++
+		return true
+	})
+	return res
+}
+
+// RemoveEgressIP stops the running go-routine which polls monitorNodes to check
+// if they are ready and reachable (if there is one running)
+func (eit *EgressIPTracker) RemoveEgressIP(nodeIP, egressIP string) {
+	nodeIntf, exists := eit.monitorNodes.Load(nodeIP)
+	if !exists {
+		return
+	}
+	node := nodeIntf.(*NodeEgress)
+	node.activeEgressIPs.Delete(egressIP)
+	if node.activeEgressIPs.Len() == 0 {
+		klog.V(4).Infof("Unmonitoring node %s", nodeIP)
+		eit.monitorNodes.Delete(nodeIP)
+		if eit.getMonitorNodesLen() == 0 && eit.stop != nil {
+			close(eit.stop)
+			eit.stop = nil
+		}
+	}
+}
+
+const (
+	defaultPollInterval = 5 * time.Second
+	repollInterval      = time.Second
+	maxRetries          = 2
+)
+
+func (eit *EgressIPTracker) poll() (bool, error) {
+	retry := eit.check(false)
+	for retry {
+		time.Sleep(repollInterval)
+		retry = eit.check(true)
+	}
+	return false, nil
+}
+
+func (eit *EgressIPTracker) check(retrying bool) bool {
+	offlineResult, needRetry := eit.getOfflineResult(retrying)
+	for nodeIP, offline := range offlineResult {
+		eit.SetNodeOffline(nodeIP, offline)
+	}
+	return needRetry
+}
+
+func (eit *EgressIPTracker) getOfflineResult(retrying bool) (map[string]bool, bool) {
+	var timeout time.Duration
+	if retrying {
+		timeout = repollInterval
+	} else {
+		timeout = defaultPollInterval
+	}
+
+	needRetry := false
+	offlineResult := make(map[string]bool)
+	eit.monitorNodes.Range(func(key, value interface{}) bool {
+		node := value.(*NodeEgress)
+		if retrying && node.retries == 0 {
+			return true
+		}
+
+		nn, err := eit.nodeInformer.Lister().Get(node.NodeName)
+		if err != nil {
+			return true
+		}
+
+		if !nodeIsReady(nn) {
+			klog.Warningf("Node %s is not Ready", node.NodeName)
+			node.offline = true
+			offlineResult[node.NodeIP] = true
+			// Return when there's a not Ready node
+			return true
+		}
+
+		online := eit.Ping(node.NodeIP, timeout)
+		if node.offline && online {
+			klog.Infof("Node %s is back online", node.NodeIP)
+			node.offline = false
+			offlineResult[node.NodeIP] = false
+		} else if !node.offline && !online {
+			node.retries++
+			if node.retries > maxRetries {
+				klog.Warningf("Node %s is offline", node.NodeIP)
+				node.retries = 0
+				node.offline = true
+				offlineResult[node.NodeIP] = true
+			} else {
+				klog.V(2).Infof("Node %s may be offline... retrying", node.NodeIP)
+				needRetry = true
+			}
+		}
+		return true
+	})
+	return offlineResult, needRetry
+}
+
 func (eit *EgressIPTracker) watchNetNamespaces(netNamespaceInformer networkinformers.NetNamespaceInformer) {
 	funcs := InformerFuncs(&networkv1.NetNamespace{}, eit.handleAddOrUpdateNetNamespace, eit.handleDeleteNetNamespace)
 	netNamespaceInformer.Informer().AddEventHandler(funcs)
@@ -412,7 +590,7 @@ func (eit *EgressIPTracker) syncEgressNodeState(eg *egressIPInfo, active bool) {
 	if active && eg.assignedNodeIP != eg.nodes[0].NodeIP {
 		klog.V(4).Infof("Assigning egress IP %s to node %s", eg.ip, eg.nodes[0].NodeIP)
 		eg.assignedNodeIP = eg.nodes[0].NodeIP
-		eit.watcher.ClaimEgressIP(eg.namespaces[0].vnid, eg.ip, eg.assignedNodeIP)
+		eit.watcher.ClaimEgressIP(eg.namespaces[0].vnid, eg.ip, eg.assignedNodeIP, eg.nodes[0].NodeName)
 	} else if !active && eg.assignedNodeIP != "" {
 		klog.V(4).Infof("Removing egress IP %s from node %s", eg.ip, eg.assignedNodeIP)
 		eit.watcher.ReleaseEgressIP(eg.ip, eg.assignedNodeIP)
@@ -470,10 +648,8 @@ func (eit *EgressIPTracker) syncEgressNamespaceState(ns *namespaceEgress) {
 	}
 }
 
+// Assumes the EgressIPTracker lock is held.
 func (eit *EgressIPTracker) SetNodeOffline(nodeIP string, offline bool) {
-	eit.Lock()
-	defer eit.Unlock()
-
 	node := eit.nodesByNodeIP[nodeIP]
 	if node == nil {
 		return
@@ -495,9 +671,6 @@ func (eit *EgressIPTracker) SetNodeOffline(nodeIP string, offline bool) {
 }
 
 func (eit *EgressIPTracker) lookupNodeIP(ip string) string {
-	eit.Lock()
-	defer eit.Unlock()
-
 	if node := eit.nodesByNodeIP[ip]; node != nil {
 		return node.sdnIP
 	}

--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -806,13 +806,13 @@ func TestOfflineEgressIPs(t *testing.T) {
 func updateAllocations(eit *EgressIPTracker, allocation map[string][]string) {
 	for nodeName, egressIPs := range allocation {
 		for _, node := range eit.nodesByNodeIP {
-			if node.nodeName == nodeName {
+			if node.NodeName == nodeName {
 				ec := []networkv1.HostSubnetEgressCIDR{}
 				for _, cidr := range node.requestedCIDRs.List() {
 					ec = append(ec, networkv1.HostSubnetEgressCIDR(cidr))
 				}
 				updateHostSubnetEgress(eit, &networkv1.HostSubnet{
-					HostIP:      node.nodeIP,
+					HostIP:      node.NodeIP,
 					EgressIPs:   StringsToHSEgressIPs(egressIPs),
 					EgressCIDRs: ec,
 				})

--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -18,7 +18,7 @@ func (w *testEIPWatcher) Synced() {
 	panic("should not be reached in unit test")
 }
 
-func (w *testEIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP string) {
+func (w *testEIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP, nodeName string) {
 	w.changes = append(w.changes, fmt.Sprintf("claim %s on %s for namespace %d", egressIP, nodeIP, vnid))
 }
 

--- a/pkg/network/master/egressip.go
+++ b/pkg/network/master/egressip.go
@@ -6,9 +6,6 @@ import (
 	"sync"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -27,20 +24,9 @@ type egressIPManager struct {
 	tracker            *common.EgressIPTracker
 	networkClient      networkclient.Interface
 	hostSubnetInformer networkinformers.HostSubnetInformer
-	nodeInformer       kcoreinformers.NodeInformer
 
 	updatePending bool
 	updatedAgain  bool
-
-	monitorNodes map[string]*egressNode
-	stop         chan struct{}
-}
-
-type egressNode struct {
-	ip      string
-	name    string
-	offline bool
-	retries int
 }
 
 func newEgressIPManager() *egressIPManager {
@@ -52,8 +38,7 @@ func newEgressIPManager() *egressIPManager {
 func (eim *egressIPManager) Start(networkClient networkclient.Interface, hostSubnetInformer networkinformers.HostSubnetInformer, netNamespaceInformer networkinformers.NetNamespaceInformer, nodeInformer kcoreinformers.NodeInformer) {
 	eim.networkClient = networkClient
 	eim.hostSubnetInformer = hostSubnetInformer
-	eim.nodeInformer = nodeInformer
-	eim.tracker.Start(hostSubnetInformer, netNamespaceInformer)
+	eim.tracker.Start(hostSubnetInformer, netNamespaceInformer, nodeInformer)
 }
 
 func (eim *egressIPManager) UpdateEgressCIDRs() {
@@ -94,7 +79,7 @@ func (eim *egressIPManager) maybeDoUpdateEgressCIDRs() (bool, error) {
 	// we won't process that until this reallocation is complete.
 
 	allocation := eim.tracker.ReallocateEgressIPs()
-	monitorNodes := make(map[string]*egressNode, len(allocation))
+	monitorNodes := []*common.NodeEgress{}
 	for nodeName, egressIPs := range allocation {
 		resultErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			hs, err := eim.hostSubnetInformer.Lister().Get(nodeName)
@@ -102,11 +87,7 @@ func (eim *egressIPManager) maybeDoUpdateEgressCIDRs() (bool, error) {
 				return err
 			}
 
-			if node := eim.monitorNodes[hs.HostIP]; node != nil {
-				monitorNodes[hs.HostIP] = node
-			} else {
-				monitorNodes[hs.HostIP] = &egressNode{ip: hs.HostIP, name: nodeName}
-			}
+			monitorNodes = append(monitorNodes, &common.NodeEgress{NodeIP: hs.HostIP, NodeName: nodeName})
 
 			oldIPs := sets.NewString(common.HSEgressIPsToStrings(hs.EgressIPs)...)
 			newIPs := sets.NewString(egressIPs...)
@@ -120,115 +101,14 @@ func (eim *egressIPManager) maybeDoUpdateEgressCIDRs() (bool, error) {
 			utilruntime.HandleError(fmt.Errorf("Could not update HostSubnet EgressIPs: %v", resultErr))
 		}
 	}
-
-	eim.monitorNodes = monitorNodes
-	if len(monitorNodes) > 0 {
-		if eim.stop == nil {
-			eim.stop = make(chan struct{})
-			go eim.poll(eim.stop)
-		}
-	} else {
-		if eim.stop != nil {
-			close(eim.stop)
-			eim.stop = nil
-		}
-	}
-
+	eim.tracker.SetMonitorNodes(monitorNodes)
 	return true, nil
-}
-
-const (
-	pollInterval   = 5 * time.Second
-	repollInterval = time.Second
-	maxRetries     = 2
-)
-
-func (eim *egressIPManager) poll(stop chan struct{}) {
-	retry := false
-	for {
-		select {
-		case <-stop:
-			return
-		default:
-		}
-
-		start := time.Now()
-		retry, err := eim.check(retry)
-		if err != nil {
-			klog.Warningf("Node may have been deleted or not exist anymore")
-		}
-		if !retry {
-			// If less than pollInterval has passed since start, then sleep until it has
-			time.Sleep(start.Add(pollInterval).Sub(time.Now()))
-		}
-	}
-}
-
-func nodeIsReady(node *v1.Node) bool {
-	nodeReady := true
-	for _, cond := range node.Status.Conditions {
-		if cond.Type == v1.NodeReady {
-			if cond.Status == v1.ConditionFalse || cond.Status == v1.ConditionUnknown {
-				nodeReady = false
-			}
-		}
-	}
-	return nodeReady
-}
-
-func (eim *egressIPManager) check(retrying bool) (bool, error) {
-	var timeout time.Duration
-	if retrying {
-		timeout = repollInterval
-	} else {
-		timeout = pollInterval
-	}
-
-	needRetry := false
-	for _, node := range eim.monitorNodes {
-		if retrying && node.retries == 0 {
-			continue
-		}
-
-		nn, err := eim.nodeInformer.Lister().Get(node.name)
-		if err != nil {
-			return false, err
-		}
-
-		if !nodeIsReady(nn) {
-			klog.Warningf("Node %s is not Ready", node.name)
-			node.offline = true
-			eim.tracker.SetNodeOffline(node.ip, true)
-			// Return when there's a not Ready node
-			return false, nil
-		}
-
-		online := eim.tracker.Ping(node.ip, timeout)
-		if node.offline && online {
-			klog.Infof("Node %s is back online", node.ip)
-			node.offline = false
-			eim.tracker.SetNodeOffline(node.ip, false)
-		} else if !node.offline && !online {
-			node.retries++
-			if node.retries > maxRetries {
-				klog.Warningf("Node %s is offline", node.ip)
-				node.retries = 0
-				node.offline = true
-				eim.tracker.SetNodeOffline(node.ip, true)
-			} else {
-				klog.V(2).Infof("Node %s may be offline... retrying", node.ip)
-				needRetry = true
-			}
-		}
-	}
-
-	return needRetry, nil
 }
 
 func (eim *egressIPManager) Synced() {
 }
 
-func (eim *egressIPManager) ClaimEgressIP(vnid uint32, egressIP, nodeIP string) {
+func (eim *egressIPManager) ClaimEgressIP(vnid uint32, egressIP, nodeIP, nodeName string) {
 }
 
 func (eim *egressIPManager) ReleaseEgressIP(egressIP, nodeIP string) {

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -383,7 +383,7 @@ func (node *OsdnNode) Start() error {
 		if err := node.SetupEgressNetworkPolicy(); err != nil {
 			return err
 		}
-		if err := node.egressIP.Start(node.networkInformers, node.nodeIPTables); err != nil {
+		if err := node.egressIP.Start(node.networkInformers, node.kubeInformers, node.nodeIPTables); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR fixes two issues. The first commit is a problem introduced by the new load balancing feature. The second commit fixes an issue that has always been existing for manual assignment of egress IPs with opensift-sdn, but which we can/might want to fix now given the first commit.

I am not certain the second commit is needed, we could just argue that it's never really worked so no need to fix it now when this plugin is reaching a deprecation phase. I added it however as I'd like to get some input on if people think it could be useful.

/assign @danwinship @JacobTanenbaum 






