### PR TITLE
no masquerade intra cluster traffic

### DIFF
--- a/pkg/network/common/common.go
+++ b/pkg/network/common/common.go
@@ -33,6 +33,7 @@ func ClusterNetworkListContains(clusterNetworks []ParsedClusterNetworkEntry, ipa
 }
 
 type ParsedClusterNetwork struct {
+	MachineNetwork  *net.IPNet
 	PluginName      string
 	ClusterNetworks []ParsedClusterNetworkEntry
 	ServiceNetwork  *net.IPNet
@@ -71,6 +72,15 @@ func ParseClusterNetwork(cn *networkv1.ClusterNetwork) (*ParsedClusterNetwork, e
 			return nil, fmt.Errorf("failed to parse ServiceNetwork CIDR %s: %v", cn.ServiceNetwork, err)
 		}
 		utilruntime.HandleError(fmt.Errorf("Configured serviceNetworkCIDR value %q is invalid; treating it as %q", cn.ServiceNetwork, pcn.ServiceNetwork.String()))
+	}
+
+	pcn.MachineNetwork, err = networkutils.ParseCIDRMask(cn.Network)
+	if err != nil {
+		_, pcn.MachineNetwork, err = net.ParseCIDR(cn.Network)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse Machine Network CIDR %s: %v", cn.Network, err)
+		}
+		utilruntime.HandleError(fmt.Errorf("Configured MachineNetworkCIDR value %q is invalid; treating it as %q", cn.Network, pcn.MachineNetwork.String()))
 	}
 
 	if cn.VXLANPort != nil {

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -349,7 +349,7 @@ func (node *OsdnNode) Start() error {
 		node.clusterCIDRs = append(node.clusterCIDRs, cn.ClusterCIDR.String())
 	}
 
-	node.nodeIPTables = newNodeIPTables(node.ipt, node.clusterCIDRs, !node.useConnTrack, node.networkInfo.VXLANPort, node.masqueradeBit)
+	node.nodeIPTables = newNodeIPTables(node.ipt, node.networkInfo.MachineNetwork.String(), node.clusterCIDRs, !node.useConnTrack, node.networkInfo.VXLANPort, node.masqueradeBit)
 	if err = node.nodeIPTables.Setup(); err != nil {
 		return fmt.Errorf("failed to set up iptables: %v", err)
 	}


### PR DESCRIPTION
Observed in https://bugzilla.redhat.com/show_bug.cgi?id=1953032

Pods traffic to nodes should not be masquerade, however, this creates an asymmetric routing problem ... should traffic directed to nodeIPs directed through the tunnel interface?

xref: https://kubernetes.io/docs/tasks/administer-cluster/ip-masq-agent/

Signed-off-by: Antonio Ojea <antonio.ojea.garcia@gmail.com>