### PR TITLE
Bug 1953530: Fix flaky unit test `TestEgressCIDRAllocation`

### DIFF
--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -1073,14 +1073,8 @@ func TestEgressCIDRAllocation(t *testing.T) {
 		NetID:     45,
 		EgressIPs: []networkv1.NetNamespaceEgressIP{"172.17.0.102", "172.17.1.102"}, // 172.17.0.102 is already allocated above
 	})
-	updateNetNamespaceEgress(eit, &networkv1.NetNamespace{
-		NetID:     49,
-		EgressIPs: []networkv1.NetNamespaceEgressIP{"172.17.0.109", "172.17.1.109"},
-	})
 	err = w.assertChanges(
 		"update egress CIDRs",
-		"update egress CIDRs",
-		"namespace 49 dropped",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -1089,14 +1083,9 @@ func TestEgressCIDRAllocation(t *testing.T) {
 	allocation = eit.ReallocateEgressIPs()
 	updateAllocations(eit, allocation)
 	err = w.assertChanges(
-		"claim 172.17.0.109 on 172.17.0.4 for namespace 49",
-		"namespace 49 via 172.17.0.109 on 172.17.0.4",
-		"claim 172.17.1.109 on 172.17.0.3 for namespace 49",
 		"claim 172.17.1.102 on 172.17.0.3 for namespace 45",
 		"namespace 45 via 172.17.0.102 on 172.17.0.4",
 		"namespace 45 via 172.17.1.102 on 172.17.0.3",
-		"namespace 49 via 172.17.1.109 on 172.17.0.3",
-		"namespace 49 via 172.17.0.109 on 172.17.0.4",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)


### PR DESCRIPTION
`TestEgressCIDRAllocation` was flaking because the tests don't perform
the same logical actions as the code does. The test case finished by
assigning multiple egress IPs to two namespaces (45 and 49) where it
was expected that all egress IPs should be assigned to two different
nodes. The tests are using a test case variable: `changes` which monitors
the state of the test execution during our tests. When the final test
case in `TestEgressCIDRAllocation` was reached: namespace 49 got assigned
two egress IPs to node 3 and node 4, each node assignment called
`SetNamespaceEgressViaEgressIPs` which cumulated the changes for
one node: effectively adding the same expected string twice. This does
not happen during our regular execution since `SetNamespaceEgressViaEgressIPs`
in pkg/network/node does not cummulate state.

It goes somewhat like this:

1) Node 3's subnet is updated and an assignment is made
2) `SetNamespaceEgressViaEgressIPs` is called and gets:
   `namespace 49 via 172.17.1.109 on 172.17.0.3` added to `changes`
3) Node 4's subnet is update and an assignment is made
4) `SetNamespaceEgressViaEgressIPs` is called and gets:
   `namespace 49 via 172.17.1.109 on 172.17.0.3`
   `namespace 49 via 172.17.0.109 on 172.17.0.4` added to `changes`

Each hostsubnet update generates a full namespace update. Thus adding
the same egress IP twice to `changes`.

This patch removes the redudant check on namespace 49. The test scenario
for namespace 45 is enough to verify that multiple egress IPs per
namespace works correctly. A better fix would have been to refactor
`egressip_test.go` and have a more "unit-y" test case setup instead of
performing multiple changes per unit test and having state mixed and
asserted between all scenarios, but due to lack of time this approach
was taken

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>