### PR TITLE
proxy: filter/delegate EndpointSlices as well as Endpoints

### DIFF
--- a/pkg/network/proxy/hybridproxier.go
+++ b/pkg/network/proxy/hybridproxier.go
@@ -1,4 +1,4 @@
-package hybrid
+package proxy
 
 import (
 	"fmt"

--- a/pkg/network/proxy/hybridproxier.go
+++ b/pkg/network/proxy/hybridproxier.go
@@ -34,8 +34,9 @@ type HybridProxier struct {
 
 	mainProxy     HybridizableProxy
 	unidlingProxy HybridizableProxy
-	minSyncPeriod time.Duration
+
 	serviceLister corev1listers.ServiceLister
+	syncRunner    *async.BoundedFrequencyRunner
 
 	// TODO(directxman12): figure out a good way to avoid duplicating this information
 	// (it's saved in the individual proxies as well)
@@ -52,9 +53,6 @@ type HybridProxier struct {
 	switchedToUserspace     map[types.NamespacedName]bool
 	switchedToUserspaceLock sync.Mutex
 
-	// A gate that prevents iptables from being exhausted by proxy calls.
-	syncRunner *async.BoundedFrequencyRunner
-
 	// This map is used in unidling proxy mode to ensure the service is correctly deleted
 	// if it's deletion occurs after the deletion of the endpoint.
 	pendingDeletion map[types.NamespacedName]bool
@@ -69,7 +67,7 @@ func NewHybridProxier(
 	p := &HybridProxier{
 		mainProxy:     mainProxy,
 		unidlingProxy: unidlingProxy,
-		minSyncPeriod: minSyncPeriod,
+
 		serviceLister: serviceLister,
 
 		usingUserspace:      make(map[types.NamespacedName]bool),

--- a/pkg/network/proxy/hybridproxier.go
+++ b/pkg/network/proxy/hybridproxier.go
@@ -18,9 +18,8 @@ import (
 	unidlingapi "github.com/openshift/api/unidling/v1alpha1"
 )
 
-// RunnableProxy is an extra interface we layer on top of Provider that
-// lets us control exactly when the proxy is synced.
-type RunnableProxy interface {
+// HybridizableProxy is an extra interface we layer on top of Provider
+type HybridizableProxy interface {
 	proxy.Provider
 
 	SyncProxyRules()
@@ -33,8 +32,8 @@ type RunnableProxy interface {
 type HybridProxier struct {
 	proxyconfig.NoopEndpointSliceHandler
 
-	mainProxy     RunnableProxy
-	unidlingProxy RunnableProxy
+	mainProxy     HybridizableProxy
+	unidlingProxy HybridizableProxy
 	minSyncPeriod time.Duration
 	serviceLister corev1listers.ServiceLister
 
@@ -62,11 +61,11 @@ type HybridProxier struct {
 }
 
 func NewHybridProxier(
-	mainProxy RunnableProxy,
-	unidlingProxy RunnableProxy,
+	mainProxy HybridizableProxy,
+	unidlingProxy HybridizableProxy,
 	minSyncPeriod time.Duration,
 	serviceLister corev1listers.ServiceLister,
-) (*HybridProxier, error) {
+) *HybridProxier {
 	p := &HybridProxier{
 		mainProxy:     mainProxy,
 		unidlingProxy: unidlingProxy,
@@ -86,7 +85,7 @@ func NewHybridProxier(
 	mainProxy.SetSyncRunner(p.syncRunner)
 	unidlingProxy.SetSyncRunner(p.syncRunner)
 
-	return p, nil
+	return p
 }
 
 func (proxier *HybridProxier) OnNodeAdd(node *corev1.Node) {
@@ -377,4 +376,10 @@ func (p *HybridProxier) SyncLoop() {
 	// All this does is start our syncRunner, since we pass it *back* in to
 	// the mainProxy
 	p.mainProxy.SyncLoop()
+}
+
+func (p *HybridProxier) SyncProxyRules() {
+}
+
+func (p *HybridProxier) SetSyncRunner(b *async.BoundedFrequencyRunner) {
 }

--- a/pkg/network/proxy/hybridproxier_test.go
+++ b/pkg/network/proxy/hybridproxier_test.go
@@ -116,7 +116,7 @@ func TestHybridProxy(t *testing.T) {
 	err = mainProxy.assertEvents("after idling first service",
 		"update service testns/one",
 		"delete service testns/one",
-		"delete endpoints testns/one 1.2.3.4",
+		"update endpoints testns/one -",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -135,7 +135,7 @@ func TestHybridProxy(t *testing.T) {
 
 	err = mainProxy.assertEvents("after unidling first service",
 		"add service testns/one",
-		"add endpoints testns/one 1.2.3.4",
+		"update endpoints testns/one 1.2.3.4",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -215,7 +215,7 @@ func TestHybridProxy(t *testing.T) {
 
 	err = mainProxy.assertEvents("after idling second service",
 		"delete service testns/two",
-		"delete endpoints testns/two 9.10.11.12",
+		"update endpoints testns/two -",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -235,7 +235,7 @@ func TestHybridProxy(t *testing.T) {
 	err = mainProxy.assertEvents("after unidling second service",
 		"add service testns/two",
 		"update service testns/two",
-		"add endpoints testns/two 9.10.11.12",
+		"update endpoints testns/two 9.10.11.12",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -298,7 +298,7 @@ func TestHybridProxy(t *testing.T) {
 	err = mainProxy.assertEvents("after idling third service",
 		"update service testns/three",
 		"delete service testns/three",
-		"delete endpoints testns/three 1.2.3.4",
+		"update endpoints testns/three -",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -332,7 +332,9 @@ func TestHybridProxy(t *testing.T) {
 	// And its endpoints
 	proxy.OnEndpointsDelete(ep3idled)
 
-	err = mainProxy.assertNoEvents("after deleting third endpoints")
+	err = mainProxy.assertEvents("after deleting third endpoints",
+		"delete endpoints testns/three -",
+	)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/network/proxy/hybridproxier_test.go
+++ b/pkg/network/proxy/hybridproxier_test.go
@@ -59,7 +59,7 @@ func deleteServiceAndWait(svc *corev1.Service, proxy *OsdnProxy) error {
 }
 
 func TestHybridProxy(t *testing.T) {
-	proxy, mainProxy, unidlingProxy, err := newTestOsdnProxy()
+	proxy, mainProxy, unidlingProxy, err := newTestOsdnProxy(true)
 	if err != nil {
 		t.Fatalf("unexpected error creating OsdnProxy: %v", err)
 	}
@@ -86,9 +86,616 @@ func TestHybridProxy(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	// Then create its endpoints. Note that the unidling proxy is told about all
-	// endpoints changes, even though it doesn't know about the service
-	ep1 := makeEndpoints("testns", "one", "1.2.3.4")
+	// Then create its endpoints.
+	_, slice1 := makeEndpoints("testns", "one", "1.2.3.4")
+	proxy.OnEndpointSliceAdd(slice1)
+
+	err = mainProxy.assertEvents("after creating first endpoints",
+		"add endpointslice testns/one 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after creating first endpoints")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Idle the service; both the service and the endpoints will be removed from the
+	// main proxy, and the service will be added to the unidling proxy.
+	svc1idled := svc1.DeepCopy()
+	svc1idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	proxy.OnServiceUpdate(svc1, svc1idled)
+
+	// Because a service needs both an annotation and empty endpoints in order to
+	// become idle, it should not be idle yet (which means also that the service
+	// update gets passed through).
+	err = mainProxy.assertEvents("after annotating service but not removing endpoints",
+		"update service testns/one",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after annotating service but not removing endpoints")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	slice1idled := slice1.DeepCopy()
+	slice1idled.Endpoints[0].Addresses = nil
+	proxy.OnEndpointSliceUpdate(slice1, slice1idled)
+
+	err = mainProxy.assertEvents("after idling first service",
+		"delete service testns/one",
+		"update endpointslice testns/one -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after idling first service",
+		"add service testns/one",
+		"add endpoints testns/one -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Unidle the service, reverting the previous change. This time neither proxy
+	// sees the "service update testns/one" because removing the annotation immediately
+	// unidles the service, so that event gets translated into the delete/add.
+	proxy.OnServiceUpdate(svc1idled, svc1)
+	proxy.OnEndpointSliceUpdate(slice1idled, slice1)
+
+	err = mainProxy.assertEvents("after unidling first service",
+		"add service testns/one",
+		"update endpointslice testns/one 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after unidling first service",
+		"delete service testns/one",
+		"update endpoints testns/one 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Modify the endpoints; the unidling proxy will see the change since
+	// the Service is still in the Unidling state
+	_, slice1modified := makeEndpoints("testns", "one", "5.6.7.8")
+	proxy.OnEndpointSliceUpdate(slice1, slice1modified)
+
+	err = mainProxy.assertEvents("after modifying first service",
+		"update endpointslice testns/one 5.6.7.8",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after modifying first service",
+		"update endpoints testns/one 5.6.7.8",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Fake out the passage of time and do another update; now the unidling
+	// proxy should see it as a delete
+	svcName := ktypes.NamespacedName{Namespace: "testns", Name: "one"}
+	hsvc := hybridProxy.getService(svcName)
+	expiredTime := time.Now().Add(-time.Hour)
+	hsvc.unidledAt = &expiredTime
+	hybridProxy.releaseService(svcName)
+
+	_, slice1modified2 := makeEndpoints("testns", "one", "9.10.11.12")
+	proxy.OnEndpointSliceUpdate(slice1modified, slice1modified2)
+
+	mainProxy.assertEvents("after re-modifying first service",
+		"update endpointslice testns/one 9.10.11.12",
+	)
+	unidlingProxy.assertEvents("after re-modifying first service",
+		"delete endpoints testns/one 5.6.7.8",
+	)
+
+	// Change the endpoints back; the unidling proxy should not see the event
+	proxy.OnEndpointSliceUpdate(slice1, slice1modified)
+
+	mainProxy.assertEvents("after re-re-modifying first service",
+		"update endpointslice testns/one 5.6.7.8",
+	)
+	unidlingProxy.assertNoEvents("after re-re-modifying first service")
+
+	// *****
+
+	// Create another service, but this time create the endpoints first
+	_, slice2 := makeEndpoints("testns", "two", "9.10.11.12")
+	proxy.OnEndpointSliceAdd(slice2)
+
+	err = mainProxy.assertEvents("after creating second endpoints",
+		"add endpointslice testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after creating second endpoints")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now create the service
+	svc2 := makeService("testns", "two")
+	err = createServiceAndWait(svc2, proxy)
+	if err != nil {
+		t.Fatalf("unexpected error creating service: %v", err)
+	}
+	proxy.OnServiceAdd(svc2)
+
+	err = mainProxy.assertEvents("after creating second service",
+		"add service testns/two",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after creating second endpoints")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Idle, then unidle the service
+	slice2idled := slice2.DeepCopy()
+	slice2idled.Endpoints[0].Addresses = nil
+	proxy.OnEndpointSliceUpdate(slice2, slice2idled)
+	svc2idled := svc2.DeepCopy()
+	svc2idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	proxy.OnServiceUpdate(svc2, svc2idled)
+
+	err = mainProxy.assertEvents("after idling second service",
+		"delete service testns/two",
+		"update endpointslice testns/two -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after idling second service",
+		"add service testns/two",
+		"add endpoints testns/two -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Since we modify the EndpointSlice first this time, the service will be unidled
+	// then, and so the Service change will be seen by the main proxy.
+	proxy.OnEndpointSliceUpdate(slice2idled, slice2)
+	proxy.OnServiceUpdate(svc2idled, svc2)
+
+	err = mainProxy.assertEvents("after unidling second service",
+		"add service testns/two",
+		"update service testns/two",
+		"update endpointslice testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after unidling second service",
+		"delete service testns/two",
+		"update endpoints testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// ****
+
+	// Create a Service, then its EndpointSlice, then empty its EndpointSlice and idle
+	// it, then delete the Service while it's idle.
+
+	svc3 := makeService("testns", "three")
+	err = createServiceAndWait(svc3, proxy)
+	if err != nil {
+		t.Fatalf("unexpected error creating service: %v", err)
+	}
+	proxy.OnServiceAdd(svc3)
+
+	err = mainProxy.assertEvents("after creating third service",
+		"add service testns/three",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after creating third service")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	_, slice3 := makeEndpoints("testns", "three", "1.2.3.4")
+	proxy.OnEndpointSliceAdd(slice3)
+
+	err = mainProxy.assertEvents("after creating third endpoints",
+		"add endpointslice testns/three 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after creating third endpoints")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	svc3idled := svc3.DeepCopy()
+	svc3idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	proxy.OnServiceUpdate(svc3, svc3idled)
+	slice3idled := slice3.DeepCopy()
+	slice3idled.Endpoints[0].Addresses = nil
+	proxy.OnEndpointSliceUpdate(slice3, slice3idled)
+
+	err = mainProxy.assertEvents("after idling third service",
+		"update service testns/three",
+		"delete service testns/three",
+		"update endpointslice testns/three -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after idling third service",
+		"add service testns/three",
+		"add endpoints testns/three -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now delete it
+	err = deleteServiceAndWait(svc3idled, proxy)
+	if err != nil {
+		t.Fatalf("unexpected error deleting service: %v", err)
+	}
+	proxy.OnServiceDelete(svc3idled)
+
+	err = mainProxy.assertNoEvents("after deleting third service")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after deleting third service",
+		"delete service testns/three",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// And its endpoints
+	proxy.OnEndpointSliceDelete(slice3idled)
+
+	err = mainProxy.assertEvents("after deleting third endpoints",
+		"delete endpointslice testns/three -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after deleting third endpoints",
+		"delete endpoints testns/three -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// ****
+
+	// Clean up
+	proxy.OnEndpointSliceDelete(slice1modified)
+
+	err = deleteServiceAndWait(svc2, proxy)
+	if err != nil {
+		t.Fatalf("unexpected error deleting service: %v", err)
+	}
+	proxy.OnServiceDelete(svc2)
+
+	proxy.OnEndpointSliceDelete(slice2)
+
+	err = deleteServiceAndWait(svc1, proxy)
+	if err != nil {
+		t.Fatalf("unexpected error deleting service: %v", err)
+	}
+	proxy.OnServiceDelete(svc1)
+
+	err = mainProxy.assertEvents("after cleanup",
+		"delete service testns/one",
+		"delete endpointslice testns/one 5.6.7.8",
+		"delete service testns/two",
+		"delete endpointslice testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after cleanup",
+		"delete endpoints testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestHybridProxyPreIdled(t *testing.T) {
+	proxy, mainProxy, unidlingProxy, err := newTestOsdnProxy(true)
+	if err != nil {
+		t.Fatalf("unexpected error creating OsdnProxy: %v", err)
+	}
+
+	// Create a Service which is already idled when it is first created
+
+	_, slicepi := makeEndpoints("testns", "pre-idled")
+	proxy.OnEndpointSliceAdd(slicepi)
+
+	svcpi := makeService("testns", "pre-idled")
+	svcpi.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	err = createServiceAndWait(svcpi, proxy)
+	if err != nil {
+		t.Fatalf("unexpected error creating service: %v", err)
+	}
+	proxy.OnServiceAdd(svcpi)
+
+	err = mainProxy.assertEvents("after creating pre-idled service",
+		"add endpointslice testns/pre-idled -",
+		"add service testns/pre-idled",
+		"delete service testns/pre-idled",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after creating pre-idled service",
+		"add service testns/pre-idled",
+		"add endpoints testns/pre-idled -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now un-idle the service
+	svcpiUnidled := makeService("testns", "pre-idled")
+	proxy.OnServiceUpdate(svcpi, svcpiUnidled)
+	_, slicepiUnidled := makeEndpoints("testns", "pre-idled", "1.2.3.4")
+	proxy.OnEndpointSliceUpdate(slicepi, slicepiUnidled)
+
+	err = mainProxy.assertEvents("after unidling pre-idled service",
+		"add service testns/pre-idled",
+		"update endpointslice testns/pre-idled 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after unidling pre-idled service",
+		"delete service testns/pre-idled",
+		"update endpoints testns/pre-idled 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now delete it
+	err = deleteServiceAndWait(svcpiUnidled, proxy)
+	if err != nil {
+		t.Fatalf("unexpected error deleting service: %v", err)
+	}
+	proxy.OnServiceDelete(svcpiUnidled)
+	proxy.OnEndpointSliceDelete(slicepiUnidled)
+
+	err = mainProxy.assertEvents("after deleting pre-idled service",
+		"delete service testns/pre-idled",
+		"delete endpointslice testns/pre-idled 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after deleting pre-idled service",
+		"delete endpoints testns/pre-idled 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestHybridProxyReIdling(t *testing.T) {
+	proxy, mainProxy, unidlingProxy, err := newTestOsdnProxy(true)
+	if err != nil {
+		t.Fatalf("unexpected error creating OsdnProxy: %v", err)
+	}
+	hybridProxy := proxy.baseProxy.(*HybridProxier)
+
+	// ****
+
+	// Create a Service, idle and unidle it, then re-idle it again while it's still in
+	// the Unidling state.
+
+	svcri := makeService("testns", "re-idle")
+	err = createServiceAndWait(svcri, proxy)
+	if err != nil {
+		t.Fatalf("unexpected error creating service: %v", err)
+	}
+	proxy.OnServiceAdd(svcri)
+
+	_, sliceri := makeEndpoints("testns", "re-idle", "1.2.3.4")
+	proxy.OnEndpointSliceAdd(sliceri)
+
+	err = mainProxy.assertEvents("after creating re-idling service",
+		"add service testns/re-idle",
+		"add endpointslice testns/re-idle 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after creating re-idle service")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Idle and then un-idle the service
+	_, sliceriIdled := makeEndpoints("testns", "re-idle")
+	proxy.OnEndpointSliceUpdate(sliceri, sliceriIdled)
+	svcriIdled := svcri.DeepCopy()
+	svcriIdled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	proxy.OnServiceUpdate(svcri, svcriIdled)
+
+	err = mainProxy.assertEvents("after idling re-idle service",
+		"delete service testns/re-idle",
+		"update endpointslice testns/re-idle -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after idling re-idle service",
+		"add service testns/re-idle",
+		"add endpoints testns/re-idle -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	proxy.OnServiceUpdate(svcriIdled, svcri)
+	proxy.OnEndpointSliceUpdate(sliceriIdled, sliceri)
+
+	err = mainProxy.assertEvents("after unidling re-idle service",
+		"add service testns/re-idle",
+		"update endpointslice testns/re-idle 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after unidling re-idle service",
+		"delete service testns/re-idle",
+		"update endpoints testns/re-idle 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now re-idle the Service; note in particular that the unidling proxy
+	// should see an "update endpoints" event this time.
+	proxy.OnEndpointSliceUpdate(sliceri, sliceriIdled)
+	proxy.OnServiceUpdate(svcri, svcriIdled)
+
+	err = mainProxy.assertEvents("after re-idling re-idle service",
+		"delete service testns/re-idle",
+		"update endpointslice testns/re-idle -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after re-idling re-idle service",
+		"add service testns/re-idle",
+		"update endpoints testns/re-idle -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Unidle
+	proxy.OnServiceUpdate(svcriIdled, svcri)
+	proxy.OnEndpointSliceUpdate(sliceriIdled, sliceri)
+
+	err = mainProxy.assertEvents("after unidling re-idle service",
+		"add service testns/re-idle",
+		"update endpointslice testns/re-idle 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after unidling re-idle service",
+		"delete service testns/re-idle",
+		"update endpoints testns/re-idle 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Fake out the passage of time...
+	svcName := ktypes.NamespacedName{Namespace: "testns", Name: "re-idle"}
+	hsvc := hybridProxy.getService(svcName)
+	expiredTime := time.Now().Add(-time.Hour)
+	hsvc.unidledAt = &expiredTime
+	hybridProxy.releaseService(svcName)
+
+	// Idle again; because the Unidling period expired this time, the events on the
+	// unidlingProxy are slightly different this time
+
+	proxy.OnEndpointSliceUpdate(sliceri, sliceriIdled)
+	proxy.OnServiceUpdate(svcri, svcriIdled)
+
+	err = mainProxy.assertEvents("after re-idling re-idle service after time passed",
+		"delete service testns/re-idle",
+		"update endpointslice testns/re-idle -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after re-idling re-idle service after time passed",
+		"add service testns/re-idle",
+		"delete endpoints testns/re-idle 1.2.3.4",
+		"add endpoints testns/re-idle -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// More time passes
+	svcName = ktypes.NamespacedName{Namespace: "testns", Name: "re-idle"}
+	hsvc = hybridProxy.getService(svcName)
+	expiredTime = time.Now().Add(-time.Hour)
+	hsvc.unidledAt = &expiredTime
+	hybridProxy.releaseService(svcName)
+
+	// And delete it
+	err = deleteServiceAndWait(svcriIdled, proxy)
+	if err != nil {
+		t.Fatalf("unexpected error deleting service: %v", err)
+	}
+	proxy.OnServiceDelete(svcriIdled)
+	proxy.OnEndpointSliceDelete(sliceriIdled)
+
+	err = mainProxy.assertEvents("after deleting re-idle service",
+		"delete endpointslice testns/re-idle -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after deleting re-idle service",
+		"delete service testns/re-idle",
+		"delete endpoints testns/re-idle -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestHybridProxyNoSlices(t *testing.T) {
+	proxy, mainProxy, unidlingProxy, err := newTestOsdnProxy(false)
+	if err != nil {
+		t.Fatalf("unexpected error creating OsdnProxy: %v", err)
+	}
+	hybridProxy := proxy.baseProxy.(*HybridProxier)
+
+	// *****
+
+	// Create a Service...
+	svc1 := makeService("testns", "one")
+	err = createServiceAndWait(svc1, proxy)
+	if err != nil {
+		t.Fatalf("unexpected error creating service: %v", err)
+	}
+	proxy.OnServiceAdd(svc1)
+
+	err = mainProxy.assertEvents("after creating first service",
+		"add service testns/one",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after creating first service")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Then create its endpoints.
+	ep1, _ := makeEndpoints("testns", "one", "1.2.3.4")
 	proxy.OnEndpointsAdd(ep1)
 
 	err = mainProxy.assertEvents("after creating first endpoints",
@@ -124,7 +731,6 @@ func TestHybridProxy(t *testing.T) {
 
 	ep1idled := ep1.DeepCopy()
 	ep1idled.Subsets[0].Addresses = nil
-	ep1idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
 	proxy.OnEndpointsUpdate(ep1, ep1idled)
 
 	err = mainProxy.assertEvents("after idling first service",
@@ -165,7 +771,7 @@ func TestHybridProxy(t *testing.T) {
 
 	// Modify the endpoints; the unidling proxy will see the change since
 	// the Service is still in the Unidling state
-	ep1modified := makeEndpoints("testns", "one", "5.6.7.8")
+	ep1modified, _ := makeEndpoints("testns", "one", "5.6.7.8")
 	proxy.OnEndpointsUpdate(ep1, ep1modified)
 
 	err = mainProxy.assertEvents("after modifying first service",
@@ -189,196 +795,32 @@ func TestHybridProxy(t *testing.T) {
 	hsvc.unidledAt = &expiredTime
 	hybridProxy.releaseService(svcName)
 
-	ep1modified2 := makeEndpoints("testns", "one", "9.10.11.12")
+	ep1modified2, _ := makeEndpoints("testns", "one", "9.10.11.12")
 	proxy.OnEndpointsUpdate(ep1modified, ep1modified2)
 
-	mainProxy.assertEvents("after re-modifying first service",
+	err = mainProxy.assertEvents("after re-modifying first service",
 		"update endpoints testns/one 9.10.11.12",
 	)
-	unidlingProxy.assertEvents("after re-modifying first service",
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after re-modifying first service",
 		"delete endpoints testns/one 5.6.7.8",
 	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	// Change the endpoints back; the unidling proxy should not see the event
 	proxy.OnEndpointsUpdate(ep1, ep1modified)
 
-	mainProxy.assertEvents("after re-re-modifying first service",
+	err = mainProxy.assertEvents("after re-re-modifying first service",
 		"update endpoints testns/one 5.6.7.8",
 	)
-	unidlingProxy.assertNoEvents("after re-re-modifying first service")
-
-	// *****
-
-	// Create another service, but this time create the endpoints first
-	ep2 := makeEndpoints("testns", "two", "9.10.11.12")
-	proxy.OnEndpointsAdd(ep2)
-
-	err = mainProxy.assertEvents("after creating second endpoints",
-		"add endpoints testns/two 9.10.11.12",
-	)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	err = unidlingProxy.assertNoEvents("after creating second endpoints")
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Now create the service
-	svc2 := makeService("testns", "two")
-	err = createServiceAndWait(svc2, proxy)
-	if err != nil {
-		t.Fatalf("unexpected error creating service: %v", err)
-	}
-	proxy.OnServiceAdd(svc2)
-
-	err = mainProxy.assertEvents("after creating second service",
-		"add service testns/two",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertNoEvents("after creating second endpoints")
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Idle, then unidle the service
-	ep2idled := ep2.DeepCopy()
-	ep2idled.Subsets[0].Addresses = nil
-	ep2idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
-	proxy.OnEndpointsUpdate(ep2, ep2idled)
-	svc2idled := svc2.DeepCopy()
-	svc2idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
-	proxy.OnServiceUpdate(svc2, svc2idled)
-
-	err = mainProxy.assertEvents("after idling second service",
-		"delete service testns/two",
-		"update endpoints testns/two -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after idling second service",
-		"add service testns/two",
-		"add endpoints testns/two -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Since we modify the Endpoints first this time, the service will be unidled
-	// then, and so the Service change will be seen by the main proxy.
-	proxy.OnEndpointsUpdate(ep2idled, ep2)
-	proxy.OnServiceUpdate(svc2idled, svc2)
-
-	err = mainProxy.assertEvents("after unidling second service",
-		"add service testns/two",
-		"update service testns/two",
-		"update endpoints testns/two 9.10.11.12",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after unidling second service",
-		"delete service testns/two",
-		"update endpoints testns/two 9.10.11.12",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// ****
-
-	// Create a Service, then its Endpoints, then empty its Endpoints and idle it,
-	// then delete the Service while it's idle.
-
-	svc3 := makeService("testns", "three")
-	err = createServiceAndWait(svc3, proxy)
-	if err != nil {
-		t.Fatalf("unexpected error creating service: %v", err)
-	}
-	proxy.OnServiceAdd(svc3)
-
-	err = mainProxy.assertEvents("after creating third service",
-		"add service testns/three",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertNoEvents("after creating third service")
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	ep3 := makeEndpoints("testns", "three", "1.2.3.4")
-	proxy.OnEndpointsAdd(ep3)
-
-	err = mainProxy.assertEvents("after creating third endpoints",
-		"add endpoints testns/three 1.2.3.4",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertNoEvents("after creating third endpoints")
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	svc3idled := svc3.DeepCopy()
-	svc3idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
-	proxy.OnServiceUpdate(svc3, svc3idled)
-	ep3idled := ep3.DeepCopy()
-	ep3idled.Subsets[0].Addresses = nil
-	ep3idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
-	proxy.OnEndpointsUpdate(ep3, ep3idled)
-
-	err = mainProxy.assertEvents("after idling third service",
-		"update service testns/three",
-		"delete service testns/three",
-		"update endpoints testns/three -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after idling third service",
-		"add service testns/three",
-		"add endpoints testns/three -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Now delete it
-	err = deleteServiceAndWait(svc3idled, proxy)
-	if err != nil {
-		t.Fatalf("unexpected error deleting service: %v", err)
-	}
-	proxy.OnServiceDelete(svc3idled)
-
-	err = mainProxy.assertNoEvents("after deleting third service")
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after deleting third service",
-		"delete service testns/three",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// And its endpoints
-	proxy.OnEndpointsDelete(ep3idled)
-
-	err = mainProxy.assertEvents("after deleting third endpoints",
-		"delete endpoints testns/three -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after deleting third endpoints",
-		"delete endpoints testns/three -",
-	)
+	err = unidlingProxy.assertNoEvents("after re-re-modifying first service")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -387,14 +829,6 @@ func TestHybridProxy(t *testing.T) {
 
 	// Clean up
 	proxy.OnEndpointsDelete(ep1modified)
-
-	err = deleteServiceAndWait(svc2, proxy)
-	if err != nil {
-		t.Fatalf("unexpected error deleting service: %v", err)
-	}
-	proxy.OnServiceDelete(svc2)
-
-	proxy.OnEndpointsDelete(ep2)
 
 	err = deleteServiceAndWait(svc1, proxy)
 	if err != nil {
@@ -405,266 +839,11 @@ func TestHybridProxy(t *testing.T) {
 	err = mainProxy.assertEvents("after cleanup",
 		"delete service testns/one",
 		"delete endpoints testns/one 5.6.7.8",
-		"delete service testns/two",
-		"delete endpoints testns/two 9.10.11.12",
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	err = unidlingProxy.assertEvents("after cleanup",
-		"delete endpoints testns/two 9.10.11.12",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-}
-
-func TestHybridProxyPreIdled(t *testing.T) {
-	proxy, mainProxy, unidlingProxy, err := newTestOsdnProxy()
-	if err != nil {
-		t.Fatalf("unexpected error creating OsdnProxy: %v", err)
-	}
-
-	// Create a Service which is already idled when it is first created
-
-	eppi := makeEndpoints("testns", "pre-idled")
-	proxy.OnEndpointsAdd(eppi)
-
-	svcpi := makeService("testns", "pre-idled")
-	svcpi.Annotations[unidlingapi.IdledAtAnnotation] = "now"
-	err = createServiceAndWait(svcpi, proxy)
-	if err != nil {
-		t.Fatalf("unexpected error creating service: %v", err)
-	}
-	proxy.OnServiceAdd(svcpi)
-
-	err = mainProxy.assertEvents("after creating pre-idled service",
-		"add endpoints testns/pre-idled -",
-		"add service testns/pre-idled",
-		"delete service testns/pre-idled",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after creating pre-idled service",
-		"add service testns/pre-idled",
-		"add endpoints testns/pre-idled -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Now un-idle the service
-	svcpiUnidled := makeService("testns", "pre-idled")
-	proxy.OnServiceUpdate(svcpi, svcpiUnidled)
-	eppiUnidled := makeEndpoints("testns", "pre-idled", "1.2.3.4")
-	proxy.OnEndpointsUpdate(eppi, eppiUnidled)
-
-	err = mainProxy.assertEvents("after unidling pre-idled service",
-		"add service testns/pre-idled",
-		"update endpoints testns/pre-idled 1.2.3.4",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after unidling pre-idled service",
-		"delete service testns/pre-idled",
-		"update endpoints testns/pre-idled 1.2.3.4",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Now delete it
-	err = deleteServiceAndWait(svcpiUnidled, proxy)
-	if err != nil {
-		t.Fatalf("unexpected error deleting service: %v", err)
-	}
-	proxy.OnServiceDelete(svcpiUnidled)
-	proxy.OnEndpointsDelete(eppiUnidled)
-
-	err = mainProxy.assertEvents("after deleting pre-idled service",
-		"delete service testns/pre-idled",
-		"delete endpoints testns/pre-idled 1.2.3.4",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after deleting pre-idled service",
-		"delete endpoints testns/pre-idled 1.2.3.4",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-}
-
-func TestHybridProxyReIdling(t *testing.T) {
-	proxy, mainProxy, unidlingProxy, err := newTestOsdnProxy()
-	if err != nil {
-		t.Fatalf("unexpected error creating OsdnProxy: %v", err)
-	}
-	hybridProxy := proxy.baseProxy.(*HybridProxier)
-
-	// ****
-
-	// Create a Service, idle and unidle it, then re-idle it again while it's still in
-	// the Unidling state.
-
-	svcri := makeService("testns", "re-idle")
-	err = createServiceAndWait(svcri, proxy)
-	if err != nil {
-		t.Fatalf("unexpected error creating service: %v", err)
-	}
-	proxy.OnServiceAdd(svcri)
-
-	epri := makeEndpoints("testns", "re-idle", "1.2.3.4")
-	proxy.OnEndpointsAdd(epri)
-
-	err = mainProxy.assertEvents("after creating re-idling service",
-		"add service testns/re-idle",
-		"add endpoints testns/re-idle 1.2.3.4",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertNoEvents("after creating re-idle service")
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Idle and then un-idle the service
-	epriIdled := makeEndpoints("testns", "re-idle")
-	proxy.OnEndpointsUpdate(epri, epriIdled)
-	svcriIdled := svcri.DeepCopy()
-	svcriIdled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
-	proxy.OnServiceUpdate(svcri, svcriIdled)
-
-	err = mainProxy.assertEvents("after idling re-idle service",
-		"delete service testns/re-idle",
-		"update endpoints testns/re-idle -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after idling re-idle service",
-		"add service testns/re-idle",
-		"add endpoints testns/re-idle -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	proxy.OnServiceUpdate(svcriIdled, svcri)
-	proxy.OnEndpointsUpdate(epriIdled, epri)
-
-	err = mainProxy.assertEvents("after unidling re-idle service",
-		"add service testns/re-idle",
-		"update endpoints testns/re-idle 1.2.3.4",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after unidling re-idle service",
-		"delete service testns/re-idle",
-		"update endpoints testns/re-idle 1.2.3.4",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Now re-idle the Service; note in particular that the unidling proxy
-	// should see an "update endpoints" event this time.
-	proxy.OnEndpointsUpdate(epri, epriIdled)
-	proxy.OnServiceUpdate(svcri, svcriIdled)
-
-	err = mainProxy.assertEvents("after re-idling re-idle service",
-		"delete service testns/re-idle",
-		"update endpoints testns/re-idle -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after re-idling re-idle service",
-		"add service testns/re-idle",
-		"update endpoints testns/re-idle -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Unidle
-	proxy.OnServiceUpdate(svcriIdled, svcri)
-	proxy.OnEndpointsUpdate(epriIdled, epri)
-
-	err = mainProxy.assertEvents("after unidling re-idle service",
-		"add service testns/re-idle",
-		"update endpoints testns/re-idle 1.2.3.4",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after unidling re-idle service",
-		"delete service testns/re-idle",
-		"update endpoints testns/re-idle 1.2.3.4",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// Fake out the passage of time...
-	svcName := ktypes.NamespacedName{Namespace: "testns", Name: "re-idle"}
-	hsvc := hybridProxy.getService(svcName)
-	expiredTime := time.Now().Add(-time.Hour)
-	hsvc.unidledAt = &expiredTime
-	hybridProxy.releaseService(svcName)
-
-	// Idle again; because the Unidling period expired this time, the events on the
-	// unidlingProxy are slightly different this time
-
-	proxy.OnEndpointsUpdate(epri, epriIdled)
-	proxy.OnServiceUpdate(svcri, svcriIdled)
-
-	err = mainProxy.assertEvents("after re-idling re-idle service after time passed",
-		"delete service testns/re-idle",
-		"update endpoints testns/re-idle -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after re-idling re-idle service after time passed",
-		"add service testns/re-idle",
-		"delete endpoints testns/re-idle 1.2.3.4",
-		"add endpoints testns/re-idle -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-
-	// More time passes
-	svcName = ktypes.NamespacedName{Namespace: "testns", Name: "re-idle"}
-	hsvc = hybridProxy.getService(svcName)
-	expiredTime = time.Now().Add(-time.Hour)
-	hsvc.unidledAt = &expiredTime
-	hybridProxy.releaseService(svcName)
-
-	// And delete it
-	err = deleteServiceAndWait(svcriIdled, proxy)
-	if err != nil {
-		t.Fatalf("unexpected error deleting service: %v", err)
-	}
-	proxy.OnServiceDelete(svcriIdled)
-	proxy.OnEndpointsDelete(epriIdled)
-
-	err = mainProxy.assertEvents("after deleting re-idle service",
-		"delete endpoints testns/re-idle -",
-	)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	err = unidlingProxy.assertEvents("after deleting re-idle service",
-		"delete service testns/re-idle",
-		"delete endpoints testns/re-idle -",
-	)
+	err = unidlingProxy.assertNoEvents("after cleanup")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/pkg/network/proxy/hybridproxier_test.go
+++ b/pkg/network/proxy/hybridproxier_test.go
@@ -1,0 +1,398 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+
+	unidlingapi "github.com/openshift/api/unidling/v1alpha1"
+)
+
+func makeService(namespace, name string) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        name,
+			UID:         ktypes.UID(namespace + "/" + name),
+			Annotations: make(map[string]string),
+		},
+	}
+
+	return svc
+}
+
+func createServiceAndWait(svc *corev1.Service, kubeClient kubernetes.Interface, serviceLister corev1listers.ServiceLister) error {
+	_, err := kubeClient.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return utilwait.Poll(10*time.Millisecond, time.Second, func() (bool, error) {
+		_, err := serviceLister.Services(svc.Namespace).Get(svc.Name)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func deleteServiceAndWait(svc *corev1.Service, kubeClient kubernetes.Interface, serviceLister corev1listers.ServiceLister) error {
+	err := kubeClient.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return utilwait.Poll(10*time.Millisecond, time.Second, func() (bool, error) {
+		_, err := serviceLister.Services(svc.Namespace).Get(svc.Name)
+		if err == nil {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func TestHybridProxy(t *testing.T) {
+	mainProxy := newTestProxy("main")
+	unidlingProxy := newTestProxy("unidling")
+
+	kubeClient := fake.NewSimpleClientset()
+	kubeInformers := informers.NewSharedInformerFactory(kubeClient, time.Hour)
+
+	proxy := &HybridProxier{
+		mainProxy:     mainProxy,
+		unidlingProxy: unidlingProxy,
+		serviceLister: kubeInformers.Core().V1().Services().Lister(),
+
+		usingUserspace:      make(map[ktypes.NamespacedName]bool),
+		switchedToUserspace: make(map[ktypes.NamespacedName]bool),
+		pendingDeletion:     make(map[ktypes.NamespacedName]bool),
+	}
+
+	stopCh := make(chan struct{})
+	kubeInformers.Start(stopCh)
+	defer close(stopCh)
+
+	// *****
+
+	// Create a Service...
+	svc1 := makeService("testns", "one")
+	err := createServiceAndWait(svc1, kubeClient, proxy.serviceLister)
+	if err != nil {
+		t.Fatalf("unexpected error creating service: %v", err)
+	}
+	proxy.OnServiceAdd(svc1)
+
+	err = mainProxy.assertEvents("after creating first service",
+		"add service testns/one",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after creating first service")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Then create its endpoints. Note that the unidling proxy is told about all
+	// endpoints changes, even though it doesn't know about the service
+	ep1 := makeEndpoints("testns", "one", "1.2.3.4")
+	proxy.OnEndpointsAdd(ep1)
+
+	err = mainProxy.assertEvents("after creating first endpoints",
+		"add endpoints testns/one 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after creating first endpoints",
+		"add endpoints testns/one 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Idle the service; both the service and the endpoints will be removed from the
+	// main proxy, and the service will be added to the unidling proxy.
+	svc1idled := svc1.DeepCopy()
+	svc1idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	proxy.OnServiceUpdate(svc1, svc1idled)
+	ep1idled := ep1.DeepCopy()
+	ep1idled.Subsets[0].Addresses = nil
+	ep1idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	proxy.OnEndpointsUpdate(ep1, ep1idled)
+
+	err = mainProxy.assertEvents("after idling first service",
+		"update service testns/one",
+		"delete service testns/one",
+		"delete endpoints testns/one 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after idling first service",
+		"add service testns/one",
+		"update endpoints testns/one -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Unidle the service, reverting the previous change
+	proxy.OnServiceUpdate(svc1idled, svc1)
+	proxy.OnEndpointsUpdate(ep1idled, ep1)
+
+	err = mainProxy.assertEvents("after unidling first service",
+		"add service testns/one",
+		"add endpoints testns/one 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after unidling first service",
+		"update service testns/one",
+		"delete service testns/one",
+		"update endpoints testns/one 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Modify the endpoints; both proxies will see the change
+	ep1modified := makeEndpoints("testns", "one", "5.6.7.8")
+	proxy.OnEndpointsUpdate(ep1, ep1modified)
+
+	err = mainProxy.assertEvents("after modifying first service",
+		"update endpoints testns/one 5.6.7.8",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after modifying first service",
+		"update endpoints testns/one 5.6.7.8",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// *****
+
+	// Create another service, but this time create the endpoints first
+	ep2 := makeEndpoints("testns", "two", "9.10.11.12")
+	proxy.OnEndpointsAdd(ep2)
+
+	err = mainProxy.assertEvents("after creating second endpoints",
+		"add endpoints testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after creating second endpoints",
+		"add endpoints testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now create the service
+	svc2 := makeService("testns", "two")
+	err = createServiceAndWait(svc2, kubeClient, proxy.serviceLister)
+	if err != nil {
+		t.Fatalf("unexpected error creating service: %v", err)
+	}
+	proxy.OnServiceAdd(svc2)
+
+	err = mainProxy.assertEvents("after creating second service",
+		"add service testns/two",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after creating second endpoints")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Idle, then unidle the service
+	ep2idled := ep2.DeepCopy()
+	ep2idled.Subsets[0].Addresses = nil
+	ep2idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	proxy.OnEndpointsUpdate(ep2, ep2idled)
+	svc2idled := svc2.DeepCopy()
+	svc2idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	proxy.OnServiceUpdate(svc2, svc2idled)
+
+	err = mainProxy.assertEvents("after idling second service",
+		"delete service testns/two",
+		"delete endpoints testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after idling second service",
+		"add service testns/two",
+		"update service testns/two",
+		"update endpoints testns/two -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	proxy.OnEndpointsUpdate(ep2idled, ep2)
+	proxy.OnServiceUpdate(svc2idled, svc2)
+
+	err = mainProxy.assertEvents("after unidling second service",
+		"add service testns/two",
+		"update service testns/two",
+		"add endpoints testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after unidling second service",
+		"delete service testns/two",
+		"update endpoints testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// ****
+
+	// Create a Service, then its Endpoints, then empty its Endpoints and idle it,
+	// then delete the Service while it's idle.
+
+	svc3 := makeService("testns", "three")
+	err = createServiceAndWait(svc3, kubeClient, proxy.serviceLister)
+	if err != nil {
+		t.Fatalf("unexpected error creating service: %v", err)
+	}
+	proxy.OnServiceAdd(svc3)
+
+	err = mainProxy.assertEvents("after creating third service",
+		"add service testns/three",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertNoEvents("after creating third service")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	ep3 := makeEndpoints("testns", "three", "1.2.3.4")
+	proxy.OnEndpointsAdd(ep3)
+
+	err = mainProxy.assertEvents("after creating third endpoints",
+		"add endpoints testns/three 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after creating third endpoints",
+		"add endpoints testns/three 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	svc3idled := svc3.DeepCopy()
+	svc3idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	proxy.OnServiceUpdate(svc3, svc3idled)
+	ep3idled := ep3.DeepCopy()
+	ep3idled.Subsets[0].Addresses = nil
+	ep3idled.Annotations[unidlingapi.IdledAtAnnotation] = "now"
+	proxy.OnEndpointsUpdate(ep3, ep3idled)
+
+	err = mainProxy.assertEvents("after idling third service",
+		"update service testns/three",
+		"delete service testns/three",
+		"delete endpoints testns/three 1.2.3.4",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after idling third service",
+		"add service testns/three",
+		"update endpoints testns/three -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now delete it
+	err = deleteServiceAndWait(svc3idled, kubeClient, proxy.serviceLister)
+	if err != nil {
+		t.Fatalf("unexpected error deleting service: %v", err)
+	}
+	proxy.OnServiceDelete(svc3idled)
+
+	err = mainProxy.assertNoEvents("after deleting third service")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after deleting third service",
+		"delete service testns/three",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// And its endpoints
+	proxy.OnEndpointsDelete(ep3idled)
+
+	err = mainProxy.assertNoEvents("after deleting third endpoints")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after deleting third endpoints",
+		"delete endpoints testns/three -",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// ****
+
+	// Clean up
+	proxy.OnEndpointsDelete(ep1modified)
+
+	err = deleteServiceAndWait(svc2, kubeClient, proxy.serviceLister)
+	if err != nil {
+		t.Fatalf("unexpected error deleting service: %v", err)
+	}
+	proxy.OnServiceDelete(svc2)
+
+	proxy.OnEndpointsDelete(ep2)
+
+	err = deleteServiceAndWait(svc1, kubeClient, proxy.serviceLister)
+	if err != nil {
+		t.Fatalf("unexpected error deleting service: %v", err)
+	}
+	proxy.OnServiceDelete(svc1)
+
+	err = mainProxy.assertEvents("after cleanup",
+		"delete service testns/one",
+		"delete endpoints testns/one 5.6.7.8",
+		"delete service testns/two",
+		"delete endpoints testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	err = unidlingProxy.assertEvents("after cleanup",
+		"delete endpoints testns/one 5.6.7.8",
+		"delete endpoints testns/two 9.10.11.12",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}

--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -304,7 +304,7 @@ func (proxy *OsdnProxy) endpointsBlocked(ep *corev1.Endpoints) bool {
 	for _, ss := range ep.Subsets {
 		for _, addr := range ss.Addresses {
 			IP := net.ParseIP(addr.IP)
-			if _, contains := common.ClusterNetworkListContains(proxy.networkInfo.ClusterNetworks, IP); !contains && !proxy.networkInfo.ServiceNetwork.Contains(IP) {
+			if !proxy.networkInfo.PodNetworkContains(IP) && !proxy.networkInfo.ServiceNetworkContains(IP) {
 				if proxy.firewallBlocksIP(ep.Namespace, IP) {
 					klog.Warningf("Service '%s' in namespace '%s' has an Endpoint pointing to firewalled destination (%s)", ep.Name, ep.Namespace, addr.IP)
 					return true

--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -345,7 +345,7 @@ func (proxy *OsdnProxy) OnEndpointsUpdate(old, ep *corev1.Endpoints) {
 	case !wasBlocked && !pep.blocked:
 		proxy.baseProxy.OnEndpointsUpdate(old, ep)
 	case !wasBlocked && pep.blocked:
-		proxy.baseProxy.OnEndpointsDelete(ep)
+		proxy.baseProxy.OnEndpointsDelete(old)
 	}
 }
 

--- a/pkg/network/proxy/proxy.go
+++ b/pkg/network/proxy/proxy.go
@@ -27,14 +27,6 @@ import (
 	"github.com/openshift/sdn/pkg/network/common"
 )
 
-// EndpointsConfigHandler is an abstract interface of objects which receive update notifications for the set of endpoints.
-type EndpointsConfigHandler interface {
-	// OnEndpointsUpdate gets called when endpoints configuration is changed for a given
-	// service on any of the configuration sources. An example is when a new
-	// service comes up, or when containers come up or down for an existing service.
-	OnEndpointsUpdate(endpoints []*corev1.Endpoints)
-}
-
 type firewallItem struct {
 	ruleType networkv1.EgressNetworkPolicyRuleType
 	net      *net.IPNet

--- a/pkg/network/proxy/proxy_test.go
+++ b/pkg/network/proxy/proxy_test.go
@@ -1,0 +1,510 @@
+// +build linux
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/config"
+
+	networkv1 "github.com/openshift/api/network/v1"
+	"github.com/openshift/sdn/pkg/network/common"
+)
+
+type testProxy struct {
+	kubeproxyconfig.NoopEndpointSliceHandler
+
+	name string
+
+	services  sets.String
+	endpoints sets.String
+	events    []string
+}
+
+func newTestProxy(name string) *testProxy {
+	return &testProxy{
+		name: name,
+
+		services:  sets.NewString(),
+		endpoints: sets.NewString(),
+	}
+}
+
+func (tp *testProxy) assertEvents(when string, events ...string) error {
+	happened := sets.NewString(tp.events...)
+	expected := sets.NewString(events...)
+	tp.events = nil
+
+	if !happened.Equal(expected) {
+		return fmt.Errorf("Bad events for %s proxy %s:\nMistakenly present: %s\nMistakenly missing: %s\n",
+			tp.name, when,
+			strings.Join(happened.Difference(expected).List(), ", "),
+			strings.Join(expected.Difference(happened).List(), ", "))
+	}
+	return nil
+}
+
+func (tp *testProxy) assertNoEvents(when string) error {
+	return tp.assertEvents(when)
+}
+
+func (tp *testProxy) OnServiceAdd(svc *corev1.Service) {
+	name := svc.Namespace + "/" + svc.Name
+	if tp.services.Has(name) {
+		panic(fmt.Sprintf("%s proxy got service add for already-existing service %s", tp.name, name))
+	}
+
+	tp.services.Insert(name)
+	tp.events = append(tp.events, fmt.Sprintf("add service %s", name))
+}
+
+func (tp *testProxy) OnServiceUpdate(old, svc *corev1.Service) {
+	name := svc.Namespace + "/" + svc.Name
+	if !tp.services.Has(name) {
+		panic(fmt.Sprintf("%s proxy got service update for non-existent service %s", tp.name, name))
+	}
+
+	tp.events = append(tp.events, fmt.Sprintf("update service %s", name))
+}
+
+func (tp *testProxy) OnServiceDelete(svc *corev1.Service) {
+	name := svc.Namespace + "/" + svc.Name
+	if !tp.services.Has(name) {
+		panic(fmt.Sprintf("%s proxy got service delete for non-existent service %s", tp.name, name))
+	}
+
+	tp.services.Delete(name)
+	tp.events = append(tp.events, fmt.Sprintf("delete service %s", name))
+}
+
+func (tp *testProxy) OnServiceSynced() {
+}
+
+func endpointIPs(ep *corev1.Endpoints) string {
+	if len(ep.Subsets) == 0 || len(ep.Subsets[0].Addresses) == 0 {
+		return "-"
+	}
+	ips := ""
+	for _, ss := range ep.Subsets {
+		for _, addr := range ss.Addresses {
+			if len(ips) > 0 {
+				ips += " "
+			}
+			ips += addr.IP
+		}
+	}
+	return ips
+}
+
+func (tp *testProxy) OnEndpointsAdd(ep *corev1.Endpoints) {
+	name := ep.Namespace + "/" + ep.Name
+	if tp.endpoints.Has(name) {
+		panic(fmt.Sprintf("%s proxy got endpoints add for already-existing endpoints %s", tp.name, name))
+	}
+
+	tp.endpoints.Insert(name)
+	tp.events = append(tp.events, fmt.Sprintf("add endpoints %s %s", name, endpointIPs(ep)))
+}
+
+func (tp *testProxy) OnEndpointsUpdate(old, ep *corev1.Endpoints) {
+	name := ep.Namespace + "/" + ep.Name
+	if !tp.endpoints.Has(name) {
+		panic(fmt.Sprintf("%s proxy got endpoints update for non-existent endpoints %s", tp.name, name))
+	}
+
+	tp.events = append(tp.events, fmt.Sprintf("update endpoints %s %s", name, endpointIPs(ep)))
+}
+
+func (tp *testProxy) OnEndpointsDelete(ep *corev1.Endpoints) {
+	name := ep.Namespace + "/" + ep.Name
+	if !tp.endpoints.Has(name) {
+		panic(fmt.Sprintf("%s proxy got endpoints delete for non-existent endpoints %s", tp.name, name))
+	}
+
+	tp.endpoints.Delete(name)
+	tp.events = append(tp.events, fmt.Sprintf("delete endpoints %s %s", name, endpointIPs(ep)))
+}
+
+func (tp *testProxy) OnEndpointsSynced() {
+}
+
+func (tp *testProxy) OnNodeAdd(node *corev1.Node) {
+}
+
+func (tp *testProxy) OnNodeUpdate(oldNode, node *corev1.Node) {
+}
+
+func (tp *testProxy) OnNodeDelete(node *corev1.Node) {
+}
+
+func (tp *testProxy) OnNodeSynced() {
+}
+
+func (tp *testProxy) Sync() {
+}
+
+func (tp *testProxy) SyncLoop() {
+}
+
+func mustParseCIDR(cidr string) *net.IPNet {
+	_, net, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic("bad CIDR string constant " + cidr)
+	}
+	return net
+}
+
+func makeEndpoints(namespace, name string, ips ...string) *corev1.Endpoints {
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			UID:       ktypes.UID(namespace + "/" + name),
+		},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: make([]corev1.EndpointAddress, len(ips)),
+				Ports: []corev1.EndpointPort{
+					{
+						Port: 80,
+					},
+				},
+			},
+		},
+	}
+	for i, ip := range ips {
+		ep.Subsets[0].Addresses[i].IP = ip
+	}
+
+	return ep
+}
+
+func TestOsdnProxy(t *testing.T) {
+	proxy, err := New(nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating Proxy: %v", err)
+	}
+	tp := newTestProxy("filtering")
+	proxy.baseProxy = tp
+	proxy.networkInfo = &common.ParsedClusterNetwork{
+		ClusterNetworks: []common.ParsedClusterNetworkEntry{
+			{ClusterCIDR: mustParseCIDR("10.128.0.0/14"), HostSubnetLength: 8},
+		},
+		ServiceNetwork: mustParseCIDR("172.30.0.0/16"),
+	}
+
+	// Create NetNamespaces
+	namespaces := make([]*networkv1.NetNamespace, 5)
+	for i, name := range []string{"default", "one", "two", "three", "four"} {
+		namespaces[i] = &networkv1.NetNamespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			NetID: uint32(i),
+		}
+		proxy.handleAddOrUpdateNetNamespace(namespaces[i], nil, watch.Added)
+	}
+
+	// Create EgressNetworkPolicy rules in "one"
+	enp1 := &networkv1.EgressNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespaces[1].Name,
+			Name:      "enp1",
+			UID:       ktypes.UID("enp1"),
+		},
+		Spec: networkv1.EgressNetworkPolicySpec{
+			Egress: []networkv1.EgressNetworkPolicyRule{
+				{
+					Type: networkv1.EgressNetworkPolicyRuleAllow,
+					To: networkv1.EgressNetworkPolicyPeer{
+						CIDRSelector: "192.168.1.1/32",
+					},
+				},
+				{
+					Type: networkv1.EgressNetworkPolicyRuleDeny,
+					To: networkv1.EgressNetworkPolicyPeer{
+						CIDRSelector: "192.168.1.0/24",
+					},
+				},
+				{
+					Type: networkv1.EgressNetworkPolicyRuleAllow,
+					To: networkv1.EgressNetworkPolicyPeer{
+						CIDRSelector: "192.168.0.0/16",
+					},
+				},
+			},
+		},
+	}
+	proxy.handleAddOrUpdateEgressNetworkPolicy(enp1, nil, watch.Added)
+
+	// Create Endpoints
+	initialEvents := sets.NewString()
+
+	ep := makeEndpoints("default", "kubernetes", "10.0.0.1", "10.0.0.2", "10.0.0.3")
+	proxy.OnEndpointsAdd(ep)
+	initialEvents.Insert("add endpoints default/kubernetes 10.0.0.1 10.0.0.2 10.0.0.3")
+
+	eps := make(map[string]map[string]*corev1.Endpoints)
+	for _, ns := range namespaces {
+		if ns.Name == "default" {
+			continue
+		}
+		eps[ns.Name] = make(map[string]*corev1.Endpoints)
+
+		ep = makeEndpoints(ns.Name, "local", "10.130.0.5", "10.131.2.5")
+		proxy.OnEndpointsAdd(ep)
+		eps[ns.Name]["local"] = ep
+		initialEvents.Insert("add endpoints " + ns.Name + "/local 10.130.0.5 10.131.2.5")
+
+		ep = makeEndpoints(ns.Name, "extfar", "1.2.3.4")
+		proxy.OnEndpointsAdd(ep)
+		eps[ns.Name]["extfar"] = ep
+		initialEvents.Insert("add endpoints " + ns.Name + "/extfar 1.2.3.4")
+
+		ep = makeEndpoints(ns.Name, "extnear", "192.168.2.5")
+		proxy.OnEndpointsAdd(ep)
+		eps[ns.Name]["extnear"] = ep
+		initialEvents.Insert("add endpoints " + ns.Name + "/extnear 192.168.2.5")
+
+		ep = makeEndpoints(ns.Name, "extbad", "192.168.1.5")
+		proxy.OnEndpointsAdd(ep)
+		eps[ns.Name]["extbad"] = ep
+		initialEvents.Insert("add endpoints " + ns.Name + "/extbad 192.168.1.5")
+
+		ep = makeEndpoints(ns.Name, "extexcept", "192.168.1.1")
+		proxy.OnEndpointsAdd(ep)
+		eps[ns.Name]["extexcept"] = ep
+		initialEvents.Insert("add endpoints " + ns.Name + "/extexcept 192.168.1.1")
+
+		ep = makeEndpoints(ns.Name, "extmixed", "10.130.0.5", "192.168.1.5")
+		proxy.OnEndpointsAdd(ep)
+		eps[ns.Name]["extmixed"] = ep
+		initialEvents.Insert("add endpoints " + ns.Name + "/extmixed 10.130.0.5 192.168.1.5")
+	}
+	// fixup: we added a few endpoints to expectedEndpoints that we don't actually expect
+	initialEvents.Delete(
+		"add endpoints one/extbad 192.168.1.5",
+		"add endpoints one/extmixed 10.130.0.5 192.168.1.5",
+	)
+
+	// *****
+
+	// Initial state
+	err = tp.assertEvents("at startup", initialEvents.UnsortedList()...)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// *****
+
+	// Add a new EgressNetworkPolicy to an existing namespace
+	enp3 := &networkv1.EgressNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespaces[3].Name,
+			Name:      "enp3",
+			UID:       ktypes.UID("enp3"),
+		},
+		Spec: networkv1.EgressNetworkPolicySpec{
+			Egress: []networkv1.EgressNetworkPolicyRule{
+				{
+					Type: networkv1.EgressNetworkPolicyRuleAllow,
+					To: networkv1.EgressNetworkPolicyPeer{
+						CIDRSelector: "192.168.1.1/32",
+					},
+				},
+				{
+					Type: networkv1.EgressNetworkPolicyRuleDeny,
+					To: networkv1.EgressNetworkPolicyPeer{
+						CIDRSelector: "0.0.0.0/0",
+					},
+				},
+			},
+		},
+	}
+	proxy.handleAddOrUpdateEgressNetworkPolicy(enp3, nil, watch.Added)
+
+	// That should result in everything external except "extexcept" being blocked
+	err = tp.assertEvents("after adding EgressNetworkPolicy to namespace three",
+		"delete endpoints three/extfar 1.2.3.4",
+		"delete endpoints three/extnear 192.168.2.5",
+		"delete endpoints three/extbad 192.168.1.5",
+		"delete endpoints three/extmixed 10.130.0.5 192.168.1.5",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// *****
+
+	// Fiddle with EgressNetworkPolicies in namespace "two". First copy "one"s ENP to "two"
+	enp2a := enp1.DeepCopy()
+	enp2a.Namespace = namespaces[2].Name
+	enp2a.Name = "enp2a"
+	enp2a.UID = ktypes.UID("enp2a")
+	proxy.handleAddOrUpdateEgressNetworkPolicy(enp2a, nil, watch.Added)
+
+	err = tp.assertEvents("after copying first EgressNetworkPolicy to namespace two",
+		"delete endpoints two/extbad 192.168.1.5",
+		"delete endpoints two/extmixed 10.130.0.5 192.168.1.5",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now copy "three"s ENP to "two" too, which should totally break external connectivity
+	enp2b := enp3.DeepCopy()
+	enp2b.Namespace = namespaces[2].Name
+	enp2b.Name = "enp2b"
+	enp2b.UID = ktypes.UID("enp2b")
+	proxy.handleAddOrUpdateEgressNetworkPolicy(enp2b, nil, watch.Added)
+
+	err = tp.assertEvents("after copying second EgressNetworkPolicy to namespace two",
+		"delete endpoints two/extfar 1.2.3.4",
+		"delete endpoints two/extnear 192.168.2.5",
+		"delete endpoints two/extexcept 192.168.1.1",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now delete the first ENP, which should result in the second becoming active
+	// (meaning "two" will allow the same things as "three")
+	proxy.handleDeleteEgressNetworkPolicy(enp2a)
+	err = tp.assertEvents("after deleting first EgressNetworkPolicy from namespace two",
+		"add endpoints two/extexcept 192.168.1.1",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Now delete the second ENP, which should unblock everything
+	proxy.handleDeleteEgressNetworkPolicy(enp2b)
+	err = tp.assertEvents("after deleting second EgressNetworkPolicy from namespace two",
+		"add endpoints two/extfar 1.2.3.4",
+		"add endpoints two/extnear 192.168.2.5",
+		"add endpoints two/extbad 192.168.1.5",
+		"add endpoints two/extmixed 10.130.0.5 192.168.1.5",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// *****
+
+	// An ENP in "default" should just be ignored
+	enpDefault := &networkv1.EgressNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespaces[0].Name,
+			Name:      "enpDefault",
+			UID:       ktypes.UID("enpDefault"),
+		},
+		Spec: networkv1.EgressNetworkPolicySpec{
+			Egress: []networkv1.EgressNetworkPolicyRule{
+				{
+					Type: networkv1.EgressNetworkPolicyRuleDeny,
+					To: networkv1.EgressNetworkPolicyPeer{
+						CIDRSelector: "0.0.0.0/0",
+					},
+				},
+			},
+		},
+	}
+	proxy.handleAddOrUpdateEgressNetworkPolicy(enpDefault, nil, watch.Added)
+	err = tp.assertNoEvents("after adding EgressNetworkPolicy to default")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	proxy.handleDeleteEgressNetworkPolicy(enpDefault)
+	err = tp.assertNoEvents("after deleting EgressNetworkPolicy from default")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// *****
+
+	// Delete namespace "four"
+	for _, ep := range eps[namespaces[4].Name] {
+		proxy.OnEndpointsDelete(ep)
+	}
+	proxy.handleDeleteNetNamespace(namespaces[4])
+	namespaces = namespaces[:4]
+
+	err = tp.assertEvents("after deleting namespace four",
+		"delete endpoints four/local 10.130.0.5 10.131.2.5",
+		"delete endpoints four/extfar 1.2.3.4",
+		"delete endpoints four/extnear 192.168.2.5",
+		"delete endpoints four/extbad 192.168.1.5",
+		"delete endpoints four/extexcept 192.168.1.1",
+		"delete endpoints four/extmixed 10.130.0.5 192.168.1.5",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// *****
+
+	// Modify Endpoints
+	for _, ns := range namespaces {
+		if ns.Name == "default" {
+			continue
+		}
+		ep := makeEndpoints(ns.Name, "local", "10.130.0.5", "10.131.1.5")
+		proxy.OnEndpointsUpdate(eps[ns.Name]["local"], ep)
+		eps[ns.Name]["local"] = ep
+
+		ep = makeEndpoints(ns.Name, "extnear", "192.168.2.5", "192.168.1.4")
+		proxy.OnEndpointsUpdate(eps[ns.Name]["extnear"], ep)
+		eps[ns.Name]["extnear"] = ep
+
+		ep = makeEndpoints(ns.Name, "extbad", "192.168.3.5")
+		proxy.OnEndpointsUpdate(eps[ns.Name]["extbad"], ep)
+		eps[ns.Name]["extbad"] = ep
+	}
+
+	err = tp.assertEvents("after modifying endpoints",
+		// In namespace one, this blocks extnear and unblocks extbad
+		"update endpoints one/local 10.130.0.5 10.131.1.5",
+		// FIXME: we are passing the wrong Endpoints in the synthesized delete event!
+		// "delete endpoints one/extnear 192.168.2.5",
+		"delete endpoints one/extnear 192.168.2.5 192.168.1.4",
+		"add endpoints one/extbad 192.168.3.5",
+
+		// In namespace two, there is no effect on blocking; we just observe the
+		// updated endpoints
+		"update endpoints two/local 10.130.0.5 10.131.1.5",
+		"update endpoints two/extnear 192.168.2.5 192.168.1.4",
+		"update endpoints two/extbad 192.168.3.5",
+
+		// In namespace three, extnear and extbad were blocked before and are
+		// still blocked, so we don't see any updates to them.
+		"update endpoints three/local 10.130.0.5 10.131.1.5",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// *****
+
+	// Modify EgressNetworkPolicy
+	enp3new := enp3.DeepCopy()
+	enp3new.Spec.Egress = enp1.Spec.Egress
+	proxy.handleAddOrUpdateEgressNetworkPolicy(enp3new, enp3, watch.Modified)
+
+	// Now namespace three will see the extbad, with the updated IP from above
+	err = tp.assertEvents("after modifying EgressNetworkPolicy",
+		"add endpoints three/extfar 1.2.3.4",
+		"add endpoints three/extbad 192.168.3.5",
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}

--- a/pkg/network/proxy/proxy_test.go
+++ b/pkg/network/proxy/proxy_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/config"
+	"k8s.io/kubernetes/pkg/util/async"
 
 	networkv1 "github.com/openshift/api/network/v1"
 	"github.com/openshift/sdn/pkg/network/common"
@@ -154,6 +155,12 @@ func (tp *testProxy) Sync() {
 func (tp *testProxy) SyncLoop() {
 }
 
+func (tp *testProxy) SyncProxyRules() {
+}
+
+func (tp *testProxy) SetSyncRunner(b *async.BoundedFrequencyRunner) {
+}
+
 func mustParseCIDR(cidr string) *net.IPNet {
 	_, net, err := net.ParseCIDR(cidr)
 	if err != nil {
@@ -165,9 +172,10 @@ func mustParseCIDR(cidr string) *net.IPNet {
 func makeEndpoints(namespace, name string, ips ...string) *corev1.Endpoints {
 	ep := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-			UID:       ktypes.UID(namespace + "/" + name),
+			Namespace:   namespace,
+			Name:        name,
+			UID:         ktypes.UID(namespace + "/" + name),
+			Annotations: make(map[string]string),
 		},
 		Subsets: []corev1.EndpointSubset{
 			{

--- a/pkg/network/proxy/proxy_test.go
+++ b/pkg/network/proxy/proxy_test.go
@@ -473,9 +473,7 @@ func TestOsdnProxy(t *testing.T) {
 	err = tp.assertEvents("after modifying endpoints",
 		// In namespace one, this blocks extnear and unblocks extbad
 		"update endpoints one/local 10.130.0.5 10.131.1.5",
-		// FIXME: we are passing the wrong Endpoints in the synthesized delete event!
-		// "delete endpoints one/extnear 192.168.2.5",
-		"delete endpoints one/extnear 192.168.2.5 192.168.1.4",
+		"delete endpoints one/extnear 192.168.2.5",
 		"add endpoints one/extbad 192.168.3.5",
 
 		// In namespace two, there is no effect on blocking; we just observe the

--- a/pkg/network/proxyimpl/hybrid/proxy.go
+++ b/pkg/network/proxyimpl/hybrid/proxy.go
@@ -227,7 +227,7 @@ func (p *HybridProxier) switchService(name types.NamespacedName) {
 
 	svc, err := p.serviceLister.Services(name.Namespace).Get(name.Name)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error while getting service %s/%s from cache: %v", name.Namespace, name.String(), err))
+		utilruntime.HandleError(fmt.Errorf("Error while getting service %s from cache: %v", name.String(), err))
 		return
 	}
 

--- a/pkg/openshift-sdn/proxy.go
+++ b/pkg/openshift-sdn/proxy.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	sdnproxy "github.com/openshift/sdn/pkg/network/proxy"
-	"github.com/openshift/sdn/pkg/network/proxyimpl/hybrid"
 	"github.com/openshift/sdn/pkg/network/proxyimpl/unidler"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -197,12 +196,12 @@ func (sdn *OpenShiftSDN) runProxy(waitChan chan<- bool) {
 		if err != nil {
 			klog.Fatalf("error: Could not initialize Kubernetes Proxy. You must run this process as root (and if containerized, in the host network namespace as privileged) to use the service proxy: %v", err)
 		}
-		hp, ok := proxier.(hybrid.RunnableProxy)
+		hp, ok := proxier.(sdnproxy.RunnableProxy)
 		if !ok {
 			// unreachable
 			klog.Fatalf("unidling proxy must be used in iptables mode")
 		}
-		proxier, err = hybrid.NewHybridProxier(
+		proxier, err = sdnproxy.NewHybridProxier(
 			hp,
 			unidlingUserspaceProxy,
 			sdn.ProxyConfig.IPTables.MinSyncPeriod.Duration,


### PR DESCRIPTION
Updates `OsdnProxy`/`HybridProxier` to handle both Endpoints and EndpointSlices, also adding unit tests and doing a bunch of refactoring along the way.

The sdn-level code is compatible with `EndpointSliceProxying` being either enabled or disabled, and also compatible with EndpointSlice support being added to the userspace proxy in the future. (In fact, this PR alone doesn't actually make openshift-sdn use EndpointSlices, because CNO is currently always passing `--feature-gates=EndpointSliceProxying=false`. But once this merges that can be reverted.

(for 4.9)

/cc @aojea 
