### PR TITLE
Bug 1943336: Taint node with NoSchedule effect when sdn pod is down

### DIFF
--- a/pkg/cmd/openshift-sdn-node/cmd.go
+++ b/pkg/cmd/openshift-sdn-node/cmd.go
@@ -159,7 +159,7 @@ func (sdn *openShiftSDN) start(stopCh <-chan struct{}) error {
 	klog.Infof("Starting node networking (%s)", version.Get().String())
 
 	serviceability.StartProfiler()
-	err := sdn.runSDN()
+	err := sdn.runSDN(stopCh)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/openshift-sdn-node/sdn.go
+++ b/pkg/cmd/openshift-sdn-node/sdn.go
@@ -36,8 +36,8 @@ func (sdn *openShiftSDN) initSDN() error {
 }
 
 // runSDN starts the sdn node process. Returns.
-func (sdn *openShiftSDN) runSDN() error {
-	return sdn.osdnNode.Start()
+func (sdn *openShiftSDN) runSDN(stopCh <-chan struct{}) error {
+	return sdn.osdnNode.Start(stopCh)
 }
 
 func (sdn *openShiftSDN) writeConfigFile() error {


### PR DESCRIPTION
What this PR does and why is it needed
UseCase: During upgrades, when the sdn pod is deleted and
before/while it gets recreated if a new pod request comes, it
will fail.

When node networking is down, we should not allow pods to be created
on that node. This PR fixes this by adding a taint on the node with
the NoScedule effect when the sdn pod receives a SIGTERM and then
removes the taint when the sdn pod finishes setting up networking
and initializing the CNI config.

Special notes for reviewers
Unit test has not been added since it is difficult to simulate the
plugin exec and start functions.

How to verify it
The added taint will be visible on the node for the brief period
of time between the deletion of sdn pod and creation of
the new one that takes its place which roughly takes ~60sec.

Description for the changelog
Taint node with NoSchedule effect when sdn pod is down and remove
the taint when the pod is available again