### PR TITLE
Bug 1959711: Reverse table order for egress IP and egress network policy set up 

### DIFF
--- a/pkg/network/node/egressip_test.go
+++ b/pkg/network/node/egressip_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	//"strconv"
 	"strings"
 	"testing"
 
@@ -72,7 +71,7 @@ type egressOVSChange struct {
 // the new/current set of flows in flows.
 func assertOVSChanges(eip *egressIPWatcher, flows *[]string, changes ...egressOVSChange) error {
 	oldFlows := *flows
-	newFlows, err := eip.oc.ovs.DumpFlows("table=100")
+	newFlows, err := eip.oc.ovs.DumpFlows("table=101")
 	if err != nil {
 		return fmt.Errorf("unexpected error dumping OVS flows: %v", err)
 	}
@@ -176,7 +175,7 @@ func setupEgressIPWatcher(t *testing.T) (*egressIPWatcher, []string) {
 	eip := newEgressIPWatcher(oc, "172.17.0.4", &masqBit)
 	eip.testModeChan = make(chan string, 10)
 
-	flows, err := eip.oc.ovs.DumpFlows("table=100")
+	flows, err := eip.oc.ovs.DumpFlows("table=101")
 	if err != nil {
 		t.Fatalf("unexpected error dumping OVS flows: %v", err)
 	}

--- a/pkg/network/node/ovs/fake_ovs_test.go
+++ b/pkg/network/node/ovs/fake_ovs_test.go
@@ -247,7 +247,7 @@ func TestFakeDumpFlows(t *testing.T) {
 	otx.AddFlow("table=0, priority=250, in_port=2, ip, nw_dst=224.0.0.0/4, actions=drop")
 	otx.AddFlow("table=80, priority=300, ip, nw_src=%s/32, actions=output:NXM_NX_REG2[]", localSubnetGateway)
 	otx.AddFlow("table=21, priority=0, actions=goto_table:30")
-	otx.AddFlow("table=30, priority=0, ip, actions=goto_table:100")
+	otx.AddFlow("table=30, priority=0, ip, actions=goto_table:99")
 	otx.AddFlow("table=0, priority=0, actions=drop")
 	otx.AddFlow("table=0, priority=100, ip, actions=goto_table:20")
 	otx.AddFlow("table=0, priority=200, in_port=1, arp, nw_src=%s, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[],goto_table:10", clusterNetworkCIDR, localSubnetCIDR)
@@ -285,7 +285,7 @@ func TestFakeDumpFlows(t *testing.T) {
 		" cookie=0, table=30, priority=50, in_port=1, ip, nw_dst=224.0.0.0/4, actions=goto_table:120",
 		" cookie=0, table=30, priority=25, ip, nw_dst=224.0.0.0/4, actions=goto_table:110",
 		" cookie=0, table=30, priority=0, arp, actions=drop",
-		" cookie=0, table=30, priority=0, ip, actions=goto_table:100",
+		" cookie=0, table=30, priority=0, ip, actions=goto_table:99",
 		" cookie=0, table=35, priority=300, ip, nw_dst=10.129.0.1, actions=ct(commit,exec(set_field:1->ct_mark),table=70)",
 		" cookie=0, table=40, priority=0, actions=drop",
 		" cookie=0, table=50, priority=0, actions=drop",
@@ -316,7 +316,7 @@ func TestFakeDumpFlows(t *testing.T) {
 		" cookie=0, table=30, priority=50, in_port=1, ip, nw_dst=224.0.0.0/4, actions=goto_table:120",
 		" cookie=0, table=30, priority=25, ip, nw_dst=224.0.0.0/4, actions=goto_table:110",
 		" cookie=0, table=30, priority=0, arp, actions=drop",
-		" cookie=0, table=30, priority=0, ip, actions=goto_table:100",
+		" cookie=0, table=30, priority=0, ip, actions=goto_table:99",
 	})
 	if err != nil {
 		t.Fatalf(err.Error())

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -457,7 +457,7 @@ func assertENPFlowAdditions(origFlows, newFlows []string, additions ...enpFlowAd
 			var change flowChange
 			change.kind = flowAdded
 			change.match = []string{
-				"table=101",
+				"table=100",
 				fmt.Sprintf("reg0=%d", addition.vnid),
 				fmt.Sprintf("priority=%d", len(addition.policy.Spec.Egress)-i),
 			}
@@ -467,7 +467,7 @@ func assertENPFlowAdditions(origFlows, newFlows []string, additions ...enpFlowAd
 				change.match = append(change.match, fmt.Sprintf("nw_dst=%s", rule.To.CIDRSelector))
 			}
 			if rule.Type == networkapi.EgressNetworkPolicyRuleAllow {
-				change.match = append(change.match, "actions=output")
+				change.match = append(change.match, "actions=goto_table:101")
 			} else {
 				change.match = append(change.match, "actions=drop")
 			}
@@ -1101,6 +1101,7 @@ var expectedFlows = []string{
 	" cookie=0, table=0, priority=0, actions=drop",
 	" cookie=0x0f46ee1a, table=10, priority=100, tun_src=10.0.123.45, actions=goto_table:30",
 	" cookie=0, table=10, priority=0, actions=drop",
+	" cookie=0, table=20, priority=300, udp, udp_dst=4789, actions=drop",
 	" cookie=0, table=20, priority=100, in_port=3, arp, arp_spa=10.128.0.2, arp_sha=00:00:0a:80:00:02/00:00:ff:ff:ff:ff, actions=load:42->NXM_NX_REG0[],goto_table:21",
 	" cookie=0, table=20, priority=100, in_port=3, ip, nw_src=10.128.0.2, actions=load:42->NXM_NX_REG0[],goto_table:21",
 	" cookie=0, table=20, priority=0, actions=drop",
@@ -1117,7 +1118,7 @@ var expectedFlows = []string{
 	" cookie=0, table=30, priority=100, ip, nw_dst=10.128.0.0/14, actions=goto_table:90",
 	" cookie=0, table=30, priority=50, in_port=1, ip, nw_dst=224.0.0.0/4, actions=goto_table:120",
 	" cookie=0, table=30, priority=25, ip, nw_dst=224.0.0.0/4, actions=goto_table:110",
-	" cookie=0, table=30, priority=0, ip, actions=goto_table:100",
+	" cookie=0, table=30, priority=0, ip, actions=goto_table:99",
 	" cookie=0, table=30, priority=0, arp, actions=drop",
 	" cookie=0, table=40, priority=100, arp, arp_tpa=10.128.0.2, actions=output:3",
 	" cookie=0, table=40, priority=0, actions=drop",
@@ -1134,22 +1135,22 @@ var expectedFlows = []string{
 	" cookie=0, table=80, priority=0, actions=drop",
 	" cookie=0x0f46ee1a, table=90, priority=100, ip, nw_dst=10.128.2.0/23, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:10.0.123.45->tun_dst,output:1",
 	" cookie=0, table=90, priority=0, actions=drop",
-	" cookie=0, table=100, priority=300, udp, udp_dst=4789, actions=drop",
-	" cookie=0, table=100, priority=200, tcp, tcp_dst=53, nw_dst=172.17.0.4, actions=output:2",
-	" cookie=0, table=100, priority=200, udp, udp_dst=53, nw_dst=172.17.0.4, actions=output:2",
-	" cookie=0, table=100, priority=150, ct_state=+rpl, actions=goto_table:101",
-	" cookie=0, table=100, priority=100, ip, reg0=37, actions=group:37",
+	" cookie=0, table=99, priority=200, tcp, tcp_dst=53, nw_dst=172.17.0.4, actions=output:2",
+	" cookie=0, table=99, priority=200, udp, udp_dst=53, nw_dst=172.17.0.4, actions=output:2",
+	" cookie=0, table=99, priority=0, actions=goto_table:100",
+	" cookie=0, table=100, priority=3, reg0=42, ip, nw_dst=192.168.0.0/16, actions=goto_table:101",
+	" cookie=0, table=100, priority=2, reg0=42, ip, nw_dst=192.168.1.0/24, actions=drop",
+	" cookie=0, table=100, priority=1, reg0=42, ip, nw_dst=192.168.1.1/32, actions=goto_table:101",
 	" cookie=0, table=100, priority=0, actions=goto_table:101",
-	" cookie=0, table=101, priority=3, reg0=42, ip, nw_dst=192.168.0.0/16, actions=output:2",
-	" cookie=0, table=101, priority=2, reg0=42, ip, nw_dst=192.168.1.0/24, actions=drop",
-	" cookie=0, table=101, priority=1, reg0=42, ip, nw_dst=192.168.1.1/32, actions=output:2",
+	" cookie=0, table=101, priority=150, ct_state=+rpl, actions=output:2",
+	" cookie=0, table=101, priority=100, ip, reg0=37, actions=group:37",
 	" cookie=0, table=101, priority=0, actions=output:2",
 	" cookie=0, table=110, reg0=99, actions=goto_table:111",
 	" cookie=0, table=110, priority=0, actions=drop",
 	" cookie=0, table=111, priority=100, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:10.0.123.45->tun_dst,output:1,set_field:10.0.45.123->tun_dst,output:1,goto_table:120",
 	" cookie=0, table=120, priority=100, reg0=99, actions=output:4,output:5,output:6",
 	" cookie=0, table=120, priority=0, actions=drop",
-	" cookie=0, table=253, actions=note:00.0A",
+	" cookie=0, table=253, actions=note:00.0B",
 }
 
 // Ensure that we do not change the OVS flows without bumping ruleVersion


### PR DESCRIPTION
A bug was introduced during the implementation of the egress IP with the
traffic load balancing feature, namely: the egress IP flows were evaluated
before the egress network policy ones - just like it was before, however: where
previously the egress IP related flows terminated in a `goto_table:101`
action (allowing the egress network policy flows to determine the final
action) the new feature had it end in `output:tun0`(thus short circuiting
any egress network policy related flows).

Since OVS group actions does not allow for a `goto_table` action, we
need to reverse the table ordering of egress IP and egress network
policy. This patch implements that.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1959711 required that
we short circuit the egress IP flows for reply traffic (in case the
egress IP matching pod is the server for whatever connection) and send
directly to egress netwok policy. This has been re-worked a bit to keep
the functionality the same. We now add the flow to the egress IP related
one, knowing that if we hit that flow the egress network policy ones
have already been evaluated. We thus need to short circuit the egress IP
flows, which we do due to the higher priority.

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>

/assign @danwinship @JacobTanenbaum 
/cc @huiran0826 

@huiran0826 - could you re-test the suite of egress network policy & egress IP test cases? I want to verify that this works without introducing a regression, sorry for the added work.  