### PR TITLE
Bug 1915849: Bump 4.6 to use OVS 2.13

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -11,7 +11,7 @@ COPY --from=builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin
 COPY --from=builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
 
 RUN INSTALL_PKGS=" \
-      openvswitch2.11 container-selinux socat ethtool nmap-ncat \
+      openvswitch2.13 container-selinux socat ethtool nmap-ncat \
       libmnl libnetfilter_conntrack conntrack-tools \
       libnfnetlink iproute procps-ng openssl \
       iputils binutils xz util-linux dbus nftables \


### PR DESCRIPTION
This was a mistake on my part. PR https://github.com/openshift/sdn/pull/238 bumped OVS on 4.5 to use 2.13 thinking 4.6 was already running 2.13. This is not the case however. So when we upgrade from 4.5 to 4.6 we actually downgrade OVS from 2.13 to 2.11. This is not really that critical since:

- the OVS that really matters runs on the host and does run 2.13 on 4.6 
- the flows written by openshift-sdn are backwards and forwards compatible between 2.11 and 2.13, so it does not actually lead to problems

I just happened to see OVS logging that it was running 2.11 on a OCP 4.6 cluster and was a bit confused.

/assign @dcbw 