### PR TITLE
Bug 1964625: NETID duplicate check is only required in NetworkPolicy Mode

### DIFF
--- a/pkg/network/node/multitenant.go
+++ b/pkg/network/node/multitenant.go
@@ -41,6 +41,10 @@ func (mp *multiTenantPlugin) SupportsVNIDs() bool {
 	return true
 }
 
+func (mp *multiTenantPlugin) AllowDuplicateNetID() bool {
+	return true
+}
+
 func (mp *multiTenantPlugin) Start(node *OsdnNode) error {
 	mp.node = node
 	mp.vnidInUse = node.oc.FindPolicyVNIDs()

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -101,6 +101,10 @@ func (np *networkPolicyPlugin) SupportsVNIDs() bool {
 	return true
 }
 
+func (np *networkPolicyPlugin) AllowDuplicateNetID() bool {
+	return false
+}
+
 func (np *networkPolicyPlugin) Start(node *OsdnNode) error {
 	np.lock.Lock()
 	defer np.lock.Unlock()

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -51,6 +51,7 @@ type osdnPolicy interface {
 	Name() string
 	Start(node *OsdnNode) error
 	SupportsVNIDs() bool
+	AllowDuplicateNetID() bool
 
 	AddNetNamespace(netns *networkapi.NetNamespace)
 	UpdateNetNamespace(netns *networkapi.NetNamespace, oldNetID uint32)

--- a/pkg/network/node/singletenant.go
+++ b/pkg/network/node/singletenant.go
@@ -21,6 +21,10 @@ func (sp *singleTenantPlugin) SupportsVNIDs() bool {
 	return false
 }
 
+func (np *singleTenantPlugin) AllowDuplicateNetID() bool {
+	return false
+}
+
 func (sp *singleTenantPlugin) Start(node *OsdnNode) error {
 	otx := node.oc.NewTransaction()
 	otx.AddFlow("table=80, priority=200, actions=output:NXM_NX_REG2[]")

--- a/pkg/network/node/vnids.go
+++ b/pkg/network/node/vnids.go
@@ -137,6 +137,11 @@ func (vmap *nodeVNIDMap) getVNID(name string) (uint32, error) {
 }
 
 func (vmap *nodeVNIDMap) findDuplicateNetID(namespace string, netID uint32) (string, bool) {
+	// Need to prevent duplicate NetID only for networkpolicy mode
+	if vmap.policy.AllowDuplicateNetID() {
+		return "", false
+	}
+
 	names := vmap.GetNamespaces(netID)
 	for _, name := range names {
 		if name != namespace {

--- a/pkg/network/node/vnids_test.go
+++ b/pkg/network/node/vnids_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNodeVNIDMap(t *testing.T) {
-	vmap := newNodeVNIDMap(nil, nil)
+	vmap := newNodeVNIDMap(NewNetworkPolicyPlugin(), nil)
 
 	// empty vmap
 


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
Bug 1928851 accidentally disabled duplicate NETID unconditionally for network policy and Multitenant which caused CI failure
this PR to limit the new behavior only for NetworkPolicy mode
UT passed with new changes

```
=== RUN   TestEgressIP
--- PASS: TestEgressIP (0.00s)
=== RUN   TestMultipleNamespaceEgressIPs
E0525 19:43:29.678553  325841 egressip.go:388] Multiple namespaces (42, 43) claiming EgressIP 172.17.0.100
E0525 19:43:29.678889  325841 egressip.go:388] Multiple namespaces (42, 44) claiming EgressIP 172.17.0.101
--- PASS: TestMultipleNamespaceEgressIPs (0.00s)
=== RUN   TestNodeIPAsEgressIP
--- PASS: TestNodeIPAsEgressIP (0.00s)
=== RUN   TestDuplicateNodeEgressIPs
E0525 19:43:29.681633  325841 egressip.go:388] Multiple nodes (172.17.0.3, 172.17.0.4) claiming EgressIP 172.17.0.100
E0525 19:43:29.682014  325841 egressip.go:388] Multiple nodes (172.17.0.3, 172.17.0.5) claiming EgressIP 172.17.0.100
E0525 19:43:29.683173  325841 egressip.go:388] Multiple nodes (172.17.0.3, 172.17.0.5) claiming EgressIP 172.17.0.100
--- PASS: TestDuplicateNodeEgressIPs (0.00s)
=== RUN   TestDuplicateNamespaceEgressIPs
E0525 19:43:29.684850  325841 egressip.go:388] Multiple namespaces (42, 43) claiming EgressIP 172.17.0.100
E0525 19:43:29.686046  325841 egressip.go:388] Multiple namespaces (42, 43) claiming EgressIP 172.17.0.100
E0525 19:43:29.687212  325841 egressip.go:388] Multiple namespaces (42, 43) claiming EgressIP 172.17.0.100
--- PASS: TestDuplicateNamespaceEgressIPs (0.00s)
=== RUN   TestMarkForVNID
--- PASS: TestMarkForVNID (0.00s)
=== RUN   TestEgressNodeRenumbering
--- PASS: TestEgressNodeRenumbering (0.00s)
=== RUN   TestNetworkPolicy
--- PASS: TestNetworkPolicy (0.55s)
=== RUN   TestOVSService
--- PASS: TestOVSService (0.00s)
=== RUN   TestOVSPod
--- PASS: TestOVSPod (0.00s)
=== RUN   TestGetPodDetails
--- PASS: TestGetPodDetails (0.00s)
=== RUN   TestOVSLocalMulticast
--- PASS: TestOVSLocalMulticast (0.00s)
=== RUN   TestOVSEgressNetworkPolicy
W0525 19:43:30.246580  325841 ovscontroller.go:541] Correcting CIDRSelector '0.0.0.0/32' to '0.0.0.0/0' in EgressNetworkPolicy :enp2
W0525 19:43:30.247290  325841 ovscontroller.go:541] Correcting CIDRSelector '0.0.0.0/32' to '0.0.0.0/0' in EgressNetworkPolicy :enp2
--- PASS: TestOVSEgressNetworkPolicy (0.01s)
=== RUN   TestAlreadySetUp
--- PASS: TestAlreadySetUp (0.00s)
=== RUN   TestFindUnusedVNIDs
--- PASS: TestFindUnusedVNIDs (0.00s)
=== RUN   TestFindPolicyVNIDs
--- PASS: TestFindPolicyVNIDs (0.00s)
=== RUN   TestSetHWAddrByIP
--- PASS: TestSetHWAddrByIP (0.00s)
=== RUN   TestRuleVersion
--- PASS: TestRuleVersion (0.00s)
=== RUN   TestPodManager
W0525 19:43:30.259212  325841 pod.go:275] CNI_ADD namespace1/pod1 failed: fail hard
W0525 19:43:30.259371  325841 pod.go:288] CNI_UPDATE namespace2/pod2 failed: fail harder
W0525 19:43:30.259526  325841 pod.go:302] CNI_DEL namespace3/pod3 failed: fail like a rock
--- PASS: TestPodManager (0.00s)
=== RUN   TestDirectPodUpdate
--- PASS: TestDirectPodUpdate (0.00s)
=== RUN   TestHostSubnetWatcher
--- PASS: TestHostSubnetWatcher (0.00s)
=== RUN   TestHostSubnetReassignment
--- PASS: TestHostSubnetReassignment (0.00s)
=== RUN   TestNodeVNIDMap
--- PASS: TestNodeVNIDMap (0.00s)
=== RUN   TestEgressVXLANMonitor
W0525 19:43:30.262775  325841 vxlan_monitor.go:252] Node 192.168.1.3 is offline
I0525 19:43:30.263046  325841 vxlan_monitor.go:227] Node 192.168.1.3 is back online
W0525 19:43:30.263214  325841 vxlan_monitor.go:252] Node 192.168.1.5 is offline
I0525 19:43:30.263293  325841 vxlan_monitor.go:227] Node 192.168.1.5 is back online
W0525 19:43:30.263465  325841 vxlan_monitor.go:252] Node 192.168.1.1 is offline
W0525 19:43:30.263679  325841 vxlan_monitor.go:252] Node 192.168.1.3 is offline
--- PASS: TestEgressVXLANMonitor (0.00s)
PASS
ok      github.com/openshift/sdn/pkg/network/node       0.603s
```