### PR TITLE
Bug 1985336: Disable conntrack for vxlan traffic.

### DIFF
--- a/pkg/network/node/iptables.go
+++ b/pkg/network/node/iptables.go
@@ -273,6 +273,28 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 		},
 	)
 
+	// Don't track vxlan traffic with conntrack, as it is not needed and decreases performance
+	chainArray = append(chainArray,
+		Chain{
+			table:    "raw",
+			name:     "OPENSHIFT-VXLAN-NOTRACK",
+			srcChain: "OUTPUT",
+			srcRule:  []string{"-m", "comment", "--comment", "disable conntrack for vxlan"},
+			rules: [][]string{
+				{"-p", "udp", "--dport", fmt.Sprintf("%d", n.vxlanPort), "-j", "NOTRACK"},
+			},
+		},
+		Chain{
+			table:    "raw",
+			name:     "OPENSHIFT-VXLAN-NOTRACK",
+			srcChain: "PREROUTING",
+			srcRule:  []string{"-m", "comment", "--comment", "disable conntrack for vxlan"},
+			rules: [][]string{
+				{"-p", "udp", "--dport", fmt.Sprintf("%d", n.vxlanPort), "-j", "NOTRACK"},
+			},
+		},
+	)
+
 	return chainArray
 }
 


### PR DESCRIPTION
It is not needed because vxlan always uses the same destination port (4789 by default) for every packet.
Keeping it can be a source of performance issues on large clusters.

Fixes [BZ#1985336](https://bugzilla.redhat.com/show_bug.cgi?id=1985336)