### PR TITLE
Bug 1980127: recopy openshift-sdn binary and cni config if they are deleted

### DIFF
--- a/pkg/openshift-sdn/sdn.go
+++ b/pkg/openshift-sdn/sdn.go
@@ -12,6 +12,13 @@ import (
 )
 
 const openshiftCNIFile string = "/etc/cni/net.d/80-openshift-network.conf"
+const openshiftCNIConfig string = `
+{
+  "cniVersion": "0.3.1",
+  "name": "openshift-sdn",
+  "type": "openshift-sdn"
+}
+`
 
 // initSDN sets up the sdn process.
 func (sdn *OpenShiftSDN) initSDN() error {
@@ -46,11 +53,5 @@ func (sdn *OpenShiftSDN) writeConfigFile() error {
 
 	// Write our CNI config file out to disk to signal to kubelet that
 	// our network plugin is ready
-	return ioutil.WriteFile(openshiftCNIFile, []byte(`
-{
-  "cniVersion": "0.3.1",
-  "name": "openshift-sdn",
-  "type": "openshift-sdn"
-}
-`), 0644)
+	return ioutil.WriteFile(openshiftCNIFile, []byte(openshiftCNIConfig), 0644)
 }


### PR DESCRIPTION
we cannot depend on the daemonset controller to seriealize pod
creation and deletion, because of this we need to verify if the CNI
config and the openshift-sdn binaries exist or have been deleted by the
previous terminating pod

Signed-off-by: Jacob Tanenbaum <jtanenba@redhat.com>