### PR TITLE
Bug 1991551: update usage of Events for 1.22 rebase

### DIFF
--- a/pkg/cmd/openshift-sdn-node/sdn.go
+++ b/pkg/cmd/openshift-sdn-node/sdn.go
@@ -42,7 +42,7 @@ func (sdn *openShiftSDN) runSDN() error {
 
 func (sdn *openShiftSDN) writeConfigFile() error {
 	// Make an event that openshift-sdn started
-	sdn.sdnRecorder.Eventf(&corev1.ObjectReference{Kind: "Node", Name: sdn.nodeName}, corev1.EventTypeNormal, "Starting", "openshift-sdn done initializing node networking.")
+	sdn.sdnRecorder.Eventf(&corev1.ObjectReference{Kind: "Node", Name: sdn.nodeName}, corev1.EventTypeNormal, "Starting", "Starting", "openshift-sdn done initializing node networking.")
 
 	// Write our CNI config file out to disk to signal to kubelet that
 	// our network plugin is ready

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -473,7 +473,7 @@ func (node *OsdnNode) killFailedPods(failed map[string]*kruntimeapi.PodSandbox) 
 	// we'll be able to set them up correctly
 	for _, sandbox := range failed {
 		podRef := &corev1.ObjectReference{Kind: "Pod", Name: sandbox.Metadata.Name, Namespace: sandbox.Metadata.Namespace, UID: types.UID(sandbox.Metadata.Uid)}
-		node.recorder.Eventf(podRef, corev1.EventTypeWarning, "NetworkFailed", "The pod's network interface has been lost and the pod will be stopped.")
+		node.recorder.Eventf(podRef, corev1.EventTypeWarning, "NetworkFailed", "SDNRestart", "The pod's network interface has been lost and the pod will be stopped.")
 
 		klog.V(5).Infof("Killing pod '%s/%s' sandbox", podRef.Namespace, podRef.Name)
 		if err := node.runtimeService.StopPodSandbox(sandbox.Id); err != nil {

--- a/pkg/network/proxy/unidler/unidlerproxy.go
+++ b/pkg/network/proxy/unidler/unidlerproxy.go
@@ -35,7 +35,7 @@ func (sig *eventSignaler) NeedPods(serviceName types.NamespacedName, port string
 	}
 
 	// HACK: make the message different to prevent event aggregation
-	sig.recorder.Eventf(&serviceRef, nil, v1.EventTypeNormal, unidlingapi.NeedPodsReason, "The service-port %s:%s needs pods.", serviceRef.Name, port)
+	sig.recorder.Eventf(&serviceRef, nil, v1.EventTypeNormal, unidlingapi.NeedPodsReason, "Unidling", "The service-port %s:%s needs pods.", serviceRef.Name, port)
 
 	return nil
 }

--- a/pkg/network/proxy/unidler/unidlerproxy.go
+++ b/pkg/network/proxy/unidler/unidlerproxy.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
-	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/proxy/userspace"
 	"k8s.io/kubernetes/pkg/util/iptables"
 	utilexec "k8s.io/utils/exec"
@@ -22,7 +22,7 @@ type NeedPodsSignaler interface {
 }
 
 type eventSignaler struct {
-	recorder events.EventRecorder
+	recorder record.EventRecorder
 }
 
 func (sig *eventSignaler) NeedPods(serviceName types.NamespacedName, port string) error {
@@ -35,14 +35,14 @@ func (sig *eventSignaler) NeedPods(serviceName types.NamespacedName, port string
 	}
 
 	// HACK: make the message different to prevent event aggregation
-	sig.recorder.Eventf(&serviceRef, nil, v1.EventTypeNormal, unidlingapi.NeedPodsReason, "Unidling", "The service-port %s:%s needs pods.", serviceRef.Name, port)
+	sig.recorder.Eventf(&serviceRef, v1.EventTypeNormal, unidlingapi.NeedPodsReason, "The service-port %s:%s needs pods.", serviceRef.Name, port)
 
 	return nil
 }
 
 // NewEventSignaler constructs a NeedPodsSignaler which signals by recording
 // an event for the service with the "NeedPods" reason.
-func NewEventSignaler(eventRecorder events.EventRecorder) NeedPodsSignaler {
+func NewEventSignaler(eventRecorder record.EventRecorder) NeedPodsSignaler {
 	return &eventSignaler{
 		recorder: eventRecorder,
 	}


### PR DESCRIPTION
The new `k8s.io/client-go/tools/events` version of `Eventf()` sneakily added a new argument before the trailing message+args, so we're ending up with events with

    Action:"The service-port %s:%s needs pods."
    Note:"test-service%!(EXTRA string=http)"

This adds an "action" to each event. The documentation is not very useful, but this seems consistent with how it is used in some places in k/k...

----

Additionally, it turns out that openshift-controller-manager is not compatible with openshift-sdn using the new Event API for unidling, because it assumes the `LastTimestamp` field of the event will be set, but this field is deprecated in `eventsv1.Event`, and not set by the convenience APIs. Thus, for now, revert back to using the legacy API for the unidling proxy.