### PR TITLE
Fix Dockerfile.fedora

### DIFF
--- a/images/sdn/Dockerfile.fedora
+++ b/images/sdn/Dockerfile.fedora
@@ -1,38 +1,38 @@
 # This can be used to build images for testing
-FROM fedora:32
+FROM fedora:34 AS builder
+
+RUN INSTALL_PKGS=" \
+      golang \
+      " && \
+    yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS
+
+WORKDIR /go/src/github.com/openshift/sdn
+COPY . .
+RUN make build --warn-undefined-variables
+RUN CGO_ENABLED=0 GO_BUILD_FLAGS="-tags no_openssl" make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/openshift-sdn-cni" --warn-undefined-variables
+
+FROM fedora:34
+COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn-node /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn-controller /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/openshift-sdn
+COPY --from=builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
 
 RUN INSTALL_PKGS=" \
       openvswitch container-selinux socat ethtool nmap-ncat \
       libmnl libnetfilter_conntrack conntrack-tools \
-      libnfnetlink iproute bridge-utils procps-ng \
-      iputils binutils xz \
-      golang procps gdb \
-      " && \
+      libnfnetlink iproute procps-ng openssl \
+      iputils binutils xz util-linux dbus nftables \
+      tcpdump gdb" && \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     mkdir -p /etc/sysconfig/cni/net.d && \
     yum clean all && rm -rf /var/cache/*
 
-WORKDIR /go/src/github.com/openshift/sdn
-
-COPY . .
 COPY ./images/iptables-scripts/iptables /usr/sbin/
 COPY ./images/iptables-scripts/iptables-save /usr/sbin/
 COPY ./images/iptables-scripts/iptables-restore /usr/sbin/
 COPY ./images/iptables-scripts/ip6tables /usr/sbin/
 COPY ./images/iptables-scripts/ip6tables-save /usr/sbin/
 COPY ./images/iptables-scripts/ip6tables-restore /usr/sbin/
-
-RUN go build -mod=vendor github.com/openshift/sdn/cmd/network-controller && \
-    go build -mod=vendor github.com/openshift/sdn/cmd/openshift-sdn && \
-    go build -mod=vendor github.com/openshift/sdn/cmd/sdn-cni-plugin && \
-    go build -mod=vendor github.com/containernetworking/plugins/plugins/ipam/host-local && \
-    go build -mod=vendor k8s.io/kubernetes/cmd/kube-proxy
-
-RUN mkdir -p /opt/cni/bin /usr/bin/cni && \
-    cp /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/openshift-sdn-node && \
-    cp /go/src/github.com/openshift/sdn/network-controller /usr/bin/openshift-sdn-controller && \
-    cp /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/openshift-sdn && \
-    cp /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
 
 LABEL io.k8s.display-name="OpenShift SDN" \
       io.k8s.description="This is a component of OpenShift and contains the default SDN implementation." \


### PR DESCRIPTION
I forgot to update `Dockerfile.fedora` for the directory renames.

But it had also bit-rotted a bit. And was pointlessly different from `Dockerfile.rhel`. This puts its back in sync (in particular, building things in the same order, using a separate build image, and installing the same rpms). Also, update from Fedora 32 to 34.

```
danw@p1:sdn (dockerfile-fedora)> diff -U1 images/sdn/Dockerfile.{fedora,rhel}
--- images/sdn/Dockerfile.fedora	2021-08-15 12:22:14.684554746 -0400
+++ images/sdn/Dockerfile.rhel	2021-08-15 12:21:42.932280813 -0400
@@ -1,9 +1,2 @@
-# This can be used to build images for testing
-FROM fedora:34 AS builder
-
-RUN INSTALL_PKGS=" \
-      golang \
-      " && \
-    yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS
-
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 AS builder
 WORKDIR /go/src/github.com/openshift/sdn
@@ -13,3 +6,3 @@
 
-FROM fedora:34
+FROM registry.ci.openshift.org/ocp/4.9:base
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn-node /usr/bin/
@@ -20,3 +13,3 @@
 RUN INSTALL_PKGS=" \
-      openvswitch container-selinux socat ethtool nmap-ncat \
+      openvswitch2.13 container-selinux socat ethtool nmap-ncat \
       libmnl libnetfilter_conntrack conntrack-tools \
@@ -24,3 +17,3 @@
       iputils binutils xz util-linux dbus nftables \
-      tcpdump gdb" && \
+      tcpdump" && \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
```