### PR TITLE
[release-4.7] Bug 1971669: Fix 4.7 SDN Egress Network Policy

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -203,7 +203,7 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 	otx.AddFlow("table=100, priority=300,udp,udp_dst=%d,actions=drop", vxlanPort)
 	otx.AddFlow("table=100, priority=200,tcp,tcp_dst=53,nw_dst=%s,actions=output:2", oc.localIP)
 	otx.AddFlow("table=100, priority=200,udp,udp_dst=53,nw_dst=%s,actions=output:2", oc.localIP)
-	otx.AddFlow("table=100, priority=150,ct_state=+rpl,actions=goto_table:101")
+	otx.AddFlow("table=100, priority=150,ct_state=+rpl,actions=output:2")
 	// eg, "table=100, priority=100, reg0=${tenant_id}, ip, actions=set_field:${tun0_mac}->eth_dst,set_field:${egress_mark}->pkt_mark,goto_table:101"
 	otx.AddFlow("table=100, priority=0, actions=goto_table:101")
 


### PR DESCRIPTION
Previoulsy [we added a flow](https://github.com/openshift/sdn/pull/236) to send reply traffic
to table 101(the ENP table) but in reality ENP
should never match on repy traffic so instead
just send it out.

This seems to already be fixed in 4.8 and greater with https://github.com/openshift/sdn/pull/299 However it can't be 
simply backported due to https://coreos.slack.com/archives/CDCP2LA9L/p1628667498274000?thread_ts=1628601796.223900&cid=CDCP2LA9L

```
 That fix was only needed because of a recent feature development for egress IP in openshift-sdn on 4.8 which broke egress network policy, that made it in before 4.8 code freeze though, and the problem never existed on 4.7. So, I am not sure it's safe to backport to 4.7 and risk breaking something else. This seems like it deserves its own fix
```

Signed-off-by: astoycos <astoycos@redhat.com>