### PR TITLE
Bug 1985336: Disable conntrack for vxlan traffic

### DIFF
--- a/pkg/network/node/iptables.go
+++ b/pkg/network/node/iptables.go
@@ -271,6 +271,28 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 		},
 	)
 
+	// Don't track vxlan traffic with conntrack, as it is not needed and decreases performance
+	chainArray = append(chainArray,
+		Chain{
+			table:    "raw",
+			name:     "OPENSHIFT-NOTRACK",
+			srcChain: "OUTPUT",
+			srcRule:  []string{"-m", "comment", "--comment", "disable conntrack for vxlan"},
+			rules: [][]string{
+				{"-p", "udp", "--dport", fmt.Sprintf("%d", n.vxlanPort), "-j", "NOTRACK"},
+			},
+		},
+		Chain{
+			table:    "raw",
+			name:     "OPENSHIFT-NOTRACK",
+			srcChain: "PREROUTING",
+			srcRule:  []string{"-m", "comment", "--comment", "disable conntrack for vxlan"},
+			rules: [][]string{
+				{"-p", "udp", "--dport", fmt.Sprintf("%d", n.vxlanPort), "-j", "NOTRACK"},
+			},
+		},
+	)
+
 	return chainArray
 }
 


### PR DESCRIPTION
Closes  #324

Pablo is out so I took over this PR and made the small fix @danwinship suggested in #324 

It is not needed because vxlan always uses the same destination port (4789 by default) for every packet.
Keeping it can be a source of performance issues on large clusters.

(cherry picked from commit 5c7c5f732f6d5521eab19c429e7fcce0db96812b)