### PR TITLE
Bug 2003859: Fix up event recorder usage (again)

### DIFF
--- a/pkg/cmd/openshift-sdn-node/sdn.go
+++ b/pkg/cmd/openshift-sdn-node/sdn.go
@@ -42,7 +42,7 @@ func (sdn *openShiftSDN) runSDN() error {
 
 func (sdn *openShiftSDN) writeConfigFile() error {
 	// Make an event that openshift-sdn started
-	sdn.sdnRecorder.Eventf(&corev1.ObjectReference{Kind: "Node", Name: sdn.nodeName}, corev1.EventTypeNormal, "Starting", "Starting", "openshift-sdn done initializing node networking.")
+	sdn.sdnRecorder.Eventf(&corev1.ObjectReference{Kind: "Node", Name: sdn.nodeName}, corev1.EventTypeNormal, "Starting", "openshift-sdn done initializing node networking.")
 
 	// Write our CNI config file out to disk to signal to kubelet that
 	// our network plugin is ready

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -473,7 +473,7 @@ func (node *OsdnNode) killFailedPods(failed map[string]*kruntimeapi.PodSandbox) 
 	// we'll be able to set them up correctly
 	for _, sandbox := range failed {
 		podRef := &corev1.ObjectReference{Kind: "Pod", Name: sandbox.Metadata.Name, Namespace: sandbox.Metadata.Namespace, UID: types.UID(sandbox.Metadata.Uid)}
-		node.recorder.Eventf(podRef, corev1.EventTypeWarning, "NetworkFailed", "SDNRestart", "The pod's network interface has been lost and the pod will be stopped.")
+		node.recorder.Eventf(podRef, corev1.EventTypeWarning, "NetworkFailed", "The pod's network interface has been lost and the pod will be stopped.")
 
 		klog.V(5).Infof("Killing pod '%s/%s' sandbox", podRef.Namespace, podRef.Name)
 		if err := node.runtimeService.StopPodSandbox(sandbox.Id); err != nil {


### PR DESCRIPTION
pkg/cmd/openshift-sdn-node creates separate recorders for the node and
the proxy, and only the proxy one got updated to the new API, but the
callers of the node one also got (partially) updated to use the new
API even though they were still using an old recorder, resulting in
events like:

    "message": "Starting%!(EXTRA string=openshift-sdn done initializing node networking.)",