### PR TITLE
NP updates preparing for egress support

### DIFF
--- a/pkg/network/node/egressip_test.go
+++ b/pkg/network/node/egressip_test.go
@@ -116,8 +116,7 @@ func assertOVSChanges(eip *egressIPWatcher, flows *[]string, changes ...egressOV
 	}
 	err = assertFlowChanges(oldFlows, newFlows, flowChanges...)
 	if err != nil {
-		return fmt.Errorf("unexpected flow changes: %v\nOrig:\n%s\nNew:\n%s", err,
-			strings.Join(oldFlows, "\n"), strings.Join(newFlows, "\n"))
+		return fmt.Errorf("unexpected flow changes: %v", err)
 	}
 
 	*flows = newFlows

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -437,7 +437,7 @@ func (np *networkPolicyPlugin) selectPodsFromNamespaces(nsLabelSel, podLabelSel 
 	}
 
 	nsLister := np.node.kubeInformers.Core().V1().Pods().Lister()
-	for namespace, vnid := range np.selectNamespacesInternal(nsSel) {
+	for namespace := range np.selectNamespacesInternal(nsSel) {
 		pods, err := nsLister.Pods(namespace).List(podSel)
 		if err != nil {
 			// Shouldn't happen
@@ -446,7 +446,7 @@ func (np *networkPolicyPlugin) selectPodsFromNamespaces(nsLabelSel, podLabelSel 
 		}
 		for _, pod := range pods {
 			if isOnPodNetwork(pod) {
-				peerFlows = append(peerFlows, fmt.Sprintf("reg0=%d, ip, nw_src=%s, ", vnid, pod.Status.PodIP))
+				peerFlows = append(peerFlows, fmt.Sprintf("ip, nw_src=%s, ", pod.Status.PodIP))
 			}
 		}
 	}
@@ -534,7 +534,7 @@ func (np *networkPolicyPlugin) parsePortFlows(policy *networkingv1.NetworkPolicy
 
 // parsePeerFlows parses the From values of a NetworkPolicyIngressRule, returning a list
 // of distinct restrictions consisting of OpenFlow match rules, each one ending with a
-// trailing "," (eg, "reg0=42, ip, nw_src=10.128.2.4, "). Every flow which is to be
+// trailing "," (eg, "ip, nw_src=10.128.2.4, "). Every flow which is to be
 // matched by the rule must match at least one of the returned restrictions. (If there are
 // no peers specified, it returns the no-op restriction "".)
 func (np *networkPolicyPlugin) parsePeerFlows(npns *npNamespace, npp *npPolicy, peers []networkingv1.NetworkPolicyPeer) []string {
@@ -552,7 +552,7 @@ func (np *networkPolicyPlugin) parsePeerFlows(npns *npNamespace, npp *npPolicy, 
 			} else {
 				npp.watchesOwnPods = true
 				for _, ip := range np.selectPods(npns, peer.PodSelector) {
-					peerFlows = append(peerFlows, fmt.Sprintf("reg0=%d, ip, nw_src=%s, ", npns.vnid, ip))
+					peerFlows = append(peerFlows, fmt.Sprintf("ip, nw_src=%s, ", ip))
 				}
 			}
 		} else if peer.NamespaceSelector != nil && peer.PodSelector == nil {

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -580,13 +580,11 @@ func (np *networkPolicyPlugin) parseNetworkPolicy(npns *npNamespace, policy *net
 					npp.watchesNamespaces = true
 					peerFlows = append(peerFlows, np.selectNamespaces(peer.NamespaceSelector)...)
 				}
-			} else {
+			} else if peer.NamespaceSelector != nil && peer.PodSelector != nil {
 				npp.watchesNamespaces = true
 				npp.watchesAllPods = true
 				peerFlows = append(peerFlows, np.selectPodsFromNamespaces(peer.NamespaceSelector, peer.PodSelector)...)
-			}
-
-			if peer.IPBlock != nil {
+			} else if peer.IPBlock != nil {
 				if peer.IPBlock.Except != nil {
 					// Currently IPBlocks with except rules are skipped.
 					klog.Warningf("IPBlocks with except rules are not supported (NetworkPolicy [%s], Namespace [%s])", policy.Name, policy.Namespace)

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -426,7 +426,7 @@ func TestNetworkPolicy(t *testing.T) {
 				watchesAllPods:    false,
 				watchesOwnPods:    true,
 				flows: []string{
-					fmt.Sprintf("ip, nw_dst=%s, reg0=%d, ip, nw_src=%s", serverIP(npns), npns.vnid, clientIP(npns)),
+					fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
 				},
 			},
 		})
@@ -517,8 +517,8 @@ func TestNetworkPolicy(t *testing.T) {
 			watchesAllPods:    true,
 			watchesOwnPods:    true,
 			flows: []string{
-				fmt.Sprintf("ip, nw_dst=%s, reg0=3, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[3])),
-				fmt.Sprintf("ip, nw_dst=%s, reg0=5, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[5])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[3])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[5])),
 			},
 		},
 	})
@@ -561,11 +561,11 @@ func TestNetworkPolicy(t *testing.T) {
 			watchesAllPods:    true,
 			watchesOwnPods:    true,
 			flows: []string{
-				fmt.Sprintf("ip, nw_dst=%s, reg0=1, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[1])),
-				fmt.Sprintf("ip, nw_dst=%s, reg0=2, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[2])),
-				fmt.Sprintf("ip, nw_dst=%s, reg0=3, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[3])),
-				fmt.Sprintf("ip, nw_dst=%s, reg0=4, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[4])),
-				fmt.Sprintf("ip, nw_dst=%s, reg0=5, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[5])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[1])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[2])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[3])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[4])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[5])),
 			},
 		},
 	})
@@ -642,7 +642,7 @@ func TestNetworkPolicy(t *testing.T) {
 					watchesAllPods:    false,
 					watchesOwnPods:    true,
 					flows: []string{
-						fmt.Sprintf("ip, nw_dst=%s, reg0=1, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
 					},
 				},
 				"allow-from-even": {
@@ -661,10 +661,10 @@ func TestNetworkPolicy(t *testing.T) {
 					watchesAllPods:    true,
 					watchesOwnPods:    true,
 					flows: []string{
-						fmt.Sprintf("ip, nw_dst=%s, reg0=3, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[3])),
-						fmt.Sprintf("ip, nw_dst=%s, reg0=5, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[5])),
-						fmt.Sprintf("ip, nw_dst=%s, reg0=7, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[7])),
-						// but NOT from reg0=9
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[3])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[5])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[7])),
+						// but NOT from namespace 9
 					},
 				},
 			})
@@ -695,7 +695,7 @@ func TestNetworkPolicy(t *testing.T) {
 					watchesAllPods:    false,
 					watchesOwnPods:    true,
 					flows: []string{
-						fmt.Sprintf("ip, nw_dst=%s, reg0=%d, ip, nw_src=%s", serverIP(npns), vnid, clientIP(npns)),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
 					},
 				},
 				"allow-from-all-clients": {
@@ -703,15 +703,15 @@ func TestNetworkPolicy(t *testing.T) {
 					watchesAllPods:    true,
 					watchesOwnPods:    true,
 					flows: []string{
-						fmt.Sprintf("ip, nw_dst=%s, reg0=1, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[1])),
-						fmt.Sprintf("ip, nw_dst=%s, reg0=2, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[2])),
-						fmt.Sprintf("ip, nw_dst=%s, reg0=3, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[3])),
-						fmt.Sprintf("ip, nw_dst=%s, reg0=4, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[4])),
-						fmt.Sprintf("ip, nw_dst=%s, reg0=5, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[5])),
-						fmt.Sprintf("ip, nw_dst=%s, reg0=6, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[6])),
-						fmt.Sprintf("ip, nw_dst=%s, reg0=7, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[7])),
-						fmt.Sprintf("ip, nw_dst=%s, reg0=8, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[8])),
-						fmt.Sprintf("ip, nw_dst=%s, reg0=9, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[9])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[1])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[2])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[3])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[4])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[5])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[6])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[7])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[8])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[9])),
 					},
 				},
 			})
@@ -742,7 +742,7 @@ func TestNetworkPolicy(t *testing.T) {
 					watchesAllPods:    false,
 					watchesOwnPods:    true,
 					flows: []string{
-						fmt.Sprintf("ip, nw_dst=%s, reg0=%d, ip, nw_src=%s", serverIP(npns), vnid, clientIP(npns)),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
 					},
 				},
 			})
@@ -840,7 +840,7 @@ func TestNetworkPolicy(t *testing.T) {
 			watchesAllPods:    false,
 			watchesOwnPods:    true,
 			flows: []string{
-				fmt.Sprintf("ip, nw_dst=%s, reg0=%d, ip, nw_src=%s", serverIP(npns4), npns4.vnid, clientIP(npns4)),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns4), clientIP(npns4)),
 			},
 		},
 	})
@@ -988,7 +988,7 @@ func TestNetworkPolicy_ipBlock(t *testing.T) {
 			watchesAllPods:    false,
 			watchesOwnPods:    true,
 			flows: []string{
-				fmt.Sprintf("reg0=0, ip, nw_src=%s", clientIP(npns)),
+				fmt.Sprintf("ip, nw_src=%s", clientIP(npns)),
 				fmt.Sprintf("ip, nw_src=192.168.0.0/16"),
 			},
 		},
@@ -1247,7 +1247,7 @@ func TestNetworkPolicy_egress(t *testing.T) {
 			watchesAllPods:    false,
 			watchesOwnPods:    true,
 			flows: []string{
-				fmt.Sprintf("reg0=%d, ip, nw_src=%s", npns.vnid, clientIP(npns)),
+				fmt.Sprintf("ip, nw_src=%s", clientIP(npns)),
 			},
 		},
 	})
@@ -1262,7 +1262,7 @@ func TestNetworkPolicy_egress(t *testing.T) {
 	err = assertFlowChanges(prevFlows, flows,
 		flowChange{
 			kind:  flowAdded,
-			match: []string{"table=80", "reg1=0", "reg0=0", "nw_src=10.0.0.2", "actions=output:NXM_NX_REG2[]"},
+			match: []string{"table=80", "reg1=0", "nw_src=10.0.0.2", "actions=output:NXM_NX_REG2[]"},
 		},
 	)
 	if err != nil {
@@ -1493,7 +1493,7 @@ func _TestNetworkPolicy_MultiplePoliciesOneNamespace(t *testing.T) {
 				watchesAllPods:    false,
 				watchesOwnPods:    true,
 				flows: []string{
-					fmt.Sprintf("ip, nw_dst=%s, reg0=%d, ip, nw_src=%s", serverIP(npns), npns.vnid, clientIP(npns)),
+					fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
 				},
 			},
 			"allow-client-to-server-2": {
@@ -1501,7 +1501,7 @@ func _TestNetworkPolicy_MultiplePoliciesOneNamespace(t *testing.T) {
 				watchesAllPods:    false,
 				watchesOwnPods:    true,
 				flows: []string{
-					fmt.Sprintf("ip, nw_dst=%s, reg0=%d, ip, nw_src=%s", serverIP(npns), npns.vnid, clientIP(npns)),
+					fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
 				},
 			},
 		})

--- a/pkg/network/node/subnets_test.go
+++ b/pkg/network/node/subnets_test.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,8 +20,7 @@ func assertHostSubnetFlowChanges(hsw *hostSubnetWatcher, flows *[]string, change
 
 	err = assertFlowChanges(oldFlows, newFlows, changes...)
 	if err != nil {
-		return fmt.Errorf("unexpected flow changes: %v\nOrig:\n%s\nNew:\n%s", err,
-			strings.Join(oldFlows, "\n"), strings.Join(newFlows, "\n"))
+		return fmt.Errorf("unexpected flow changes: %v", err)
 	}
 
 	*flows = newFlows


### PR DESCRIPTION
This makes a bunch of updates to the NP code with not a whole lot of visible effect. But:
- it fixes a bug that made us do a lot of useless extra processing whenever you had ipBlock policies
- it adds and updates some unit tests
- it changes the flows we generate for podSelector matches in a way that should have no effect (but _might_ slightly improve efficiency)
- it adds a gigantic doc comment to `ovscontroller.go` explaining how it all works

/cc @astoycos @msherif1234 