### PR TITLE
Replace utilruntime.HandleError() with klog.Errorf()

### DIFF
--- a/pkg/cmd/openshift-sdn-node/cmd.go
+++ b/pkg/cmd/openshift-sdn-node/cmd.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/klog/v2"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
@@ -187,11 +186,11 @@ func (sdn *openShiftSDN) start(stopCh <-chan struct{}) error {
 // reloadIPTables reloads node and proxy iptables rules after a flush
 func (sdn *openShiftSDN) reloadIPTables() {
 	if err := sdn.osdnNode.ReloadIPTables(); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Reloading openshift node iptables rules failed: %v", err))
+		klog.Errorf("Reloading openshift node iptables rules failed: %v", err)
 	}
 	if sdn.osdnProxy != nil {
 		if err := sdn.osdnProxy.ReloadIPTables(); err != nil {
-			utilruntime.HandleError(fmt.Errorf("Reloading openshift proxy iptables rules failed: %v", err))
+			klog.Errorf("Reloading openshift proxy iptables rules failed: %v", err)
 		}
 	}
 }

--- a/pkg/network/common/cniserver/cniserver.go
+++ b/pkg/network/common/cniserver/cniserver.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gorilla/mux"
 	"k8s.io/klog/v2"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -193,7 +192,7 @@ func (s *CNIServer) Start(requestFunc cniRequestFunc) error {
 	s.SetKeepAlivesEnabled(false)
 	go utilwait.Forever(func() {
 		if err := s.Serve(l); err != nil {
-			utilruntime.HandleError(fmt.Errorf("CNI server Serve() failed: %v", err))
+			klog.Errorf("CNI server Serve() failed: %v", err)
 		}
 	}, 0)
 	return nil

--- a/pkg/network/common/common.go
+++ b/pkg/network/common/common.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
 
 	osdnv1 "github.com/openshift/api/network/v1"
 	osdnclient "github.com/openshift/client-go/network/clientset/versioned"
@@ -58,7 +58,7 @@ func ParseClusterNetwork(cn *osdnv1.ClusterNetwork) (*ParsedClusterNetwork, erro
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse ClusterNetwork CIDR %s: %v", entry.CIDR, err)
 			}
-			utilruntime.HandleError(fmt.Errorf("Configured clusterNetworks value %q is invalid; treating it as %q", entry.CIDR, cidr.String()))
+			klog.Errorf("Configured clusterNetworks value %q is invalid; treating it as %q", entry.CIDR, cidr.String())
 		}
 		pcn.ClusterNetworks = append(pcn.ClusterNetworks, ParsedClusterNetworkEntry{ClusterCIDR: cidr, HostSubnetLength: entry.HostSubnetLength})
 	}
@@ -70,7 +70,7 @@ func ParseClusterNetwork(cn *osdnv1.ClusterNetwork) (*ParsedClusterNetwork, erro
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse ServiceNetwork CIDR %s: %v", cn.ServiceNetwork, err)
 		}
-		utilruntime.HandleError(fmt.Errorf("Configured serviceNetworkCIDR value %q is invalid; treating it as %q", cn.ServiceNetwork, pcn.ServiceNetwork.String()))
+		klog.Errorf("Configured serviceNetworkCIDR value %q is invalid; treating it as %q", cn.ServiceNetwork, pcn.ServiceNetwork.String())
 	}
 
 	if cn.VXLANPort != nil {

--- a/pkg/network/common/egress_dns.go
+++ b/pkg/network/common/egress_dns.go
@@ -8,7 +8,6 @@ import (
 
 	osdnv1 "github.com/openshift/api/network/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -48,7 +47,7 @@ type EgressDNS struct {
 func NewEgressDNS(ipv4, ipv6 bool) (*EgressDNS, error) {
 	dnsInfo, err := NewDNS("/etc/resolv.conf", ipv4, ipv6)
 	if err != nil {
-		utilruntime.HandleError(err)
+		klog.Errorf("Error creating EgressDNS: %v", err)
 		return nil, err
 	}
 	return &EgressDNS{
@@ -72,7 +71,7 @@ func (e *EgressDNS) Add(policy osdnv1.EgressNetworkPolicy) {
 				e.dnsNamesToPolicies[rule.To.DNSName] = sets.NewString(string(policy.UID))
 				//only call Add if the dnsName doesn't exist in the dnsNamesToPolicies
 				if err := e.dns.Add(rule.To.DNSName); err != nil {
-					utilruntime.HandleError(err)
+					klog.Errorf("Error adding EgressNetworkPolicy DNSName rule: %v", err)
 				}
 				e.signalAdded()
 			} else {

--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/klog/v2"
 
 	ktypes "k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -186,7 +185,7 @@ func (eit *EgressIPTracker) handleAddOrUpdateHostSubnet(obj, _ interface{}, even
 	klog.V(5).Infof("Watch %s event for HostSubnet %q", eventType, hs.Name)
 
 	if err := ValidateHostSubnetEgress(hs); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Ignoring invalid HostSubnet %s: %v", HostSubnetToString(hs), err))
+		klog.Errorf("Ignoring invalid HostSubnet %s: %v", HostSubnetToString(hs), err)
 		return
 	}
 
@@ -211,7 +210,7 @@ func (eit *EgressIPTracker) UpdateHostSubnetEgress(hs *osdnv1.HostSubnet) {
 	if hs.Subnet != "" {
 		_, cidr, err := net.ParseCIDR(hs.Subnet)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("could not parse HostSubnet %q CIDR: %v", hs.Name, err))
+			klog.Errorf("Could not parse HostSubnet %q CIDR: %v", hs.Name, err)
 		}
 		sdnIP = GenerateDefaultGateway(cidr).String()
 	}
@@ -385,7 +384,7 @@ func (eit *EgressIPTracker) syncEgressIPs() {
 	for eg := range changedEgressIPs {
 		active, err := eit.egressIPActive(eg)
 		if err != nil {
-			utilruntime.HandleError(err)
+			klog.Errorf("Error processing egress IPs: %v", err)
 		}
 		eit.syncEgressNodeState(eg, active)
 	}

--- a/pkg/network/common/informers.go
+++ b/pkg/network/common/informers.go
@@ -1,13 +1,12 @@
 package common
 
 import (
-	"fmt"
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	kcache "k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 )
 
 type InformerAddOrUpdateFunc func(interface{}, interface{}, watch.EventType)
@@ -28,13 +27,13 @@ func InformerFuncs(objType runtime.Object, addOrUpdateFunc InformerAddOrUpdateFu
 			if reflect.TypeOf(objType) != reflect.TypeOf(obj) {
 				tombstone, ok := obj.(kcache.DeletedFinalStateUnknown)
 				if !ok {
-					utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone: %+v", obj))
+					klog.Errorf("Couldn't get object from tombstone: %+v", obj)
 					return
 				}
 
 				obj = tombstone.Obj
 				if reflect.TypeOf(objType) != reflect.TypeOf(obj) {
-					utilruntime.HandleError(fmt.Errorf("Tombstone contained object, expected resource type: %v but got: %v", reflect.TypeOf(objType), reflect.TypeOf(obj)))
+					klog.Errorf("Tombstone contained object, expected resource type: %v but got: %v", reflect.TypeOf(objType), reflect.TypeOf(obj))
 					return
 				}
 			}

--- a/pkg/network/master/egressip.go
+++ b/pkg/network/master/egressip.go
@@ -2,7 +2,6 @@ package master
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 	"k8s.io/klog/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	kcoreinformers "k8s.io/client-go/informers/core/v1"
@@ -117,7 +115,7 @@ func (eim *egressIPManager) maybeDoUpdateEgressCIDRs() (bool, error) {
 			return err
 		})
 		if resultErr != nil {
-			utilruntime.HandleError(fmt.Errorf("Could not update HostSubnet EgressIPs: %v", resultErr))
+			klog.Errorf("Could not update HostSubnet EgressIPs: %v", resultErr)
 		}
 	}
 

--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -2,12 +2,10 @@ package master
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	kcoreinformers "k8s.io/client-go/informers/core/v1"
@@ -74,7 +72,7 @@ func Start(kClient kclientset.Interface,
 		return err
 	}
 	if err = master.checkClusterNetworkAgainstClusterObjects(); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Cluster contains objects incompatible with ClusterNetwork: %v", err))
+		klog.Errorf("Cluster contains objects incompatible with ClusterNetwork: %v", err)
 	}
 
 	// FIXME: this is required to register informers for the types we care about to ensure the informers are started.

--- a/pkg/network/node/egress_network_policy.go
+++ b/pkg/network/node/egress_network_policy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/sdn/pkg/network/common"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -66,7 +65,7 @@ func (plugin *OsdnNode) handleDeleteEgressNetworkPolicy(obj interface{}) {
 func (plugin *OsdnNode) handleEgressNetworkPolicy(policy *osdnv1.EgressNetworkPolicy, eventType watch.EventType) {
 	vnid, err := plugin.policy.GetVNID(policy.Namespace)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Could not find netid for namespace %q: %v", policy.Namespace, err))
+		klog.Errorf("Could not find netid for namespace %q: %v", policy.Namespace, err)
 		return
 	}
 

--- a/pkg/network/node/metrics/metrics.go
+++ b/pkg/network/node/metrics/metrics.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -10,10 +9,9 @@ import (
 	"sync"
 	"time"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -141,7 +139,7 @@ func updateARPMetrics() {
 	var used int
 	data, err := ioutil.ReadFile("/proc/net/arp")
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("failed to read ARP entries for metrics: %v", err))
+		klog.Errorf("Failed to read ARP entries for metrics: %v", err)
 		return
 	}
 	lines := strings.Split(string(data), "\n")
@@ -155,7 +153,7 @@ func updateARPMetrics() {
 		// gc_thresh* may not exist in some cases; don't log an error
 		return
 	} else if err != nil {
-		utilruntime.HandleError(fmt.Errorf("failed to read max ARP entries for metrics: %T %v", err, err))
+		klog.Errorf("Failed to read max ARP entries for metrics: %T %v", err, err)
 		return
 	}
 
@@ -167,7 +165,7 @@ func updateARPMetrics() {
 		}
 		ARPCacheAvailableEntries.Set(float64(available))
 	} else {
-		utilruntime.HandleError(fmt.Errorf("failed to parse max ARP entries %q for metrics: %T %v", data, err, err))
+		klog.Errorf("Failed to parse max ARP entries %q for metrics: %T %v", data, err, err)
 	}
 }
 
@@ -178,7 +176,7 @@ func updatePodIPMetrics() {
 		// Don't log an error if the directory doesn't exist (eg, no pods started yet)
 		return
 	} else if err != nil {
-		utilruntime.HandleError(fmt.Errorf("failed to read pod IPs for metrics: %v", err))
+		klog.Errorf("Failed to read pod IPs for metrics: %v", err)
 	}
 
 	for _, i := range items {

--- a/pkg/network/node/multitenant.go
+++ b/pkg/network/node/multitenant.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/openshift/library-go/pkg/network/networkutils"
@@ -13,7 +12,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	osdnv1 "github.com/openshift/api/network/v1"
@@ -69,11 +67,11 @@ func (mp *multiTenantPlugin) updatePodNetwork(namespace string, oldNetID, netID 
 
 	pods, err := mp.node.GetRunningPods(namespace)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Could not get list of local pods in namespace %q: %v", namespace, err))
+		klog.Errorf("Could not get list of local pods in namespace %q: %v", namespace, err)
 	}
 	services, err := mp.node.kClient.CoreV1().Services(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Could not get list of services in namespace %q: %v", namespace, err))
+		klog.Errorf("Could not get list of services in namespace %q: %v", namespace, err)
 		services = &corev1.ServiceList{}
 	}
 
@@ -82,7 +80,7 @@ func (mp *multiTenantPlugin) updatePodNetwork(namespace string, oldNetID, netID 
 		for _, pod := range pods {
 			err = mp.node.UpdatePod(pod)
 			if err != nil {
-				utilruntime.HandleError(fmt.Errorf("Could not update pod %q in namespace %q: %v", pod.Name, namespace, err))
+				klog.Errorf("Could not update pod %q in namespace %q: %v", pod.Name, namespace, err)
 			}
 		}
 
@@ -148,7 +146,7 @@ func (mp *multiTenantPlugin) EnsureVNIDRules(vnid uint32) {
 	otx := mp.node.oc.NewTransaction()
 	otx.AddFlow("table=80, priority=100, reg0=%d, reg1=%d, actions=output:NXM_NX_REG2[]", vnid, vnid)
 	if err := otx.Commit(); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error adding OVS flow for VNID: %v", err))
+		klog.Errorf("Error adding OVS flow for VNID: %v", err)
 	}
 }
 
@@ -165,6 +163,6 @@ func (mp *multiTenantPlugin) SyncVNIDRules() {
 		otx.DeleteFlows("table=80, reg1=%d", vnid)
 	}
 	if err := otx.Commit(); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error deleting syncing OVS VNID rules: %v", err))
+		klog.Errorf("Error deleting syncing OVS VNID rules: %v", err)
 	}
 }

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -18,7 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	kruntimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog/v2"
@@ -229,7 +228,7 @@ func (m *podManager) updateLocalMulticastRulesWithLock(vnid uint32) {
 	}
 
 	if err := m.ovs.UpdateLocalMulticastFlows(vnid, enabled, ofports); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error updating OVS multicast flows for VNID %d: %v", vnid, err))
+		klog.Errorf("Error updating OVS multicast flows for VNID %d: %v", vnid, err)
 
 	}
 }

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/sdn/pkg/network/common"
 
 	corev1 "k8s.io/api/core/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/util/sysctl"
 
@@ -94,7 +93,7 @@ func deleteLocalSubnetRoute(device, localSubnetCIDR string) {
 	})
 
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error removing %s route from dev %s: %v; if the route appears later it will not be deleted.", localSubnetCIDR, device, err))
+		klog.Errorf("Error removing %s route from dev %s: %v; if the route appears later it will not be deleted.", localSubnetCIDR, device, err)
 	}
 }
 
@@ -200,20 +199,20 @@ func (plugin *OsdnNode) updateEgressNetworkPolicyRules(vnid uint32) {
 	policies := plugin.egressPolicies[vnid]
 	namespaces := plugin.policy.GetNamespaces(vnid)
 	if err := plugin.oc.UpdateEgressNetworkPolicyRules(policies, vnid, namespaces, plugin.egressDNS); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error updating OVS flows for EgressNetworkPolicy: %v", err))
+		klog.Errorf("Error updating OVS flows for EgressNetworkPolicy: %v", err)
 	}
 }
 
 func (plugin *OsdnNode) AddServiceRules(service *corev1.Service, netID uint32) {
 	klog.V(5).Infof("AddServiceRules for %v", service)
 	if err := plugin.oc.AddServiceRules(service, netID); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error adding OVS flows for service %v, netid %d: %v", service, netID, err))
+		klog.Errorf("Error adding OVS flows for service %v, netid %d: %v", service, netID, err)
 	}
 }
 
 func (plugin *OsdnNode) DeleteServiceRules(service *corev1.Service) {
 	klog.V(5).Infof("DeleteServiceRules for %v", service)
 	if err := plugin.oc.DeleteServiceRules(service); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error deleting OVS flows for service %v: %v", service, err))
+		klog.Errorf("Error deleting OVS flows for service %v: %v", service, err)
 	}
 }

--- a/pkg/network/node/subnets.go
+++ b/pkg/network/node/subnets.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -48,12 +47,12 @@ func (hsw *hostSubnetWatcher) handleAddOrUpdateHostSubnet(obj, _ interface{}, ev
 	klog.V(5).Infof("Watch %s event for HostSubnet %q", eventType, hs.Name)
 
 	if err := common.ValidateHostSubnet(hs); err != nil {
-		utilruntime.HandleError(fmt.Errorf("Ignoring invalid HostSubnet %s: %v", common.HostSubnetToString(hs), err))
+		klog.Errorf("Ignoring invalid HostSubnet %s: %v", common.HostSubnetToString(hs), err)
 		return
 	}
 
 	if err := hsw.updateHostSubnet(hs); err != nil {
-		utilruntime.HandleError(err)
+		klog.Errorf("Error processing new/updated HostSubnet: %v", err)
 	}
 }
 
@@ -62,7 +61,7 @@ func (hsw *hostSubnetWatcher) handleDeleteHostSubnet(obj interface{}) {
 	klog.V(5).Infof("Watch %s event for HostSubnet %q", watch.Deleted, hs.Name)
 
 	if err := hsw.deleteHostSubnet(hs); err != nil {
-		utilruntime.HandleError(err)
+		klog.Errorf("Error processing deleted HostSubnet: %v", err)
 	}
 }
 

--- a/pkg/network/proxy/hybridproxier.go
+++ b/pkg/network/proxy/hybridproxier.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/util/async"
@@ -159,7 +157,7 @@ func (p *HybridProxier) releaseService(svcName types.NamespacedName) {
 	if hsvc.knownService && (hsvc.shouldBeIdled() != hsvc.isIdled) {
 		service, err := p.serviceLister.Services(svcName.Namespace).Get(svcName.Name)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("Error while getting service %s from cache: %v", svcName, err))
+			klog.Errorf("Error while getting service %s from cache: %v", svcName, err)
 			return
 		}
 

--- a/pkg/util/ovs/ovs.go
+++ b/pkg/util/ovs/ovs.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	metrics "github.com/openshift/sdn/pkg/network/node/metrics"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/exec"
@@ -418,7 +417,7 @@ func (ovsif *ovsExec) UpdateOVSMetrics() {
 	if err == nil {
 		metrics.OVSFlows.Set(float64(len(flows)))
 	} else {
-		utilruntime.HandleError(fmt.Errorf("failed to dump OVS flows for metrics: %v", err))
+		klog.Errorf("Failed to dump OVS flows for metrics: %v", err)
 	}
 }
 


### PR DESCRIPTION
A long long time ago when openshift-sdn was still in-process in
kubelet/kcm, someone told us we had to use utilruntime.HandleError to
handle errors because it was extensible/configurable/etc. But these
days we know neither openshift-snd-node nor openshift-sdn-controller
makes use of that extensibility/configurability/etc, and using
HandleError() is inconvenient because we usually have to do
"utilruntime.HandleError(fmt.Errorf("...: %v", err))" anyway. So just
stop doing that.