### PR TITLE
WIP: Metrics: Add server for Egress IP/firewall

### DIFF
--- a/pkg/network/master/egress_network_policy.go
+++ b/pkg/network/master/egress_network_policy.go
@@ -1,0 +1,52 @@
+package master
+
+import (
+	"k8s.io/apimachinery/pkg/watch"
+
+	osdnv1 "github.com/openshift/api/network/v1"
+	osdninformers "github.com/openshift/client-go/network/informers/externalversions/network/v1"
+	"github.com/openshift/sdn/pkg/network/common"
+	"github.com/openshift/sdn/pkg/network/master/metrics"
+)
+
+type egressNetworkPolicyManager struct {
+	policyCount int
+	ruleCount   int
+}
+
+func newEgressNetworkPolicyManager() *egressNetworkPolicyManager {
+	return &egressNetworkPolicyManager{}
+}
+
+func (enp *egressNetworkPolicyManager) start(informer osdninformers.EgressNetworkPolicyInformer) {
+	informer.Informer().AddEventHandler(
+		common.InformerFuncs(&osdnv1.EgressNetworkPolicy{}, enp.handleAddUpdate, enp.handleDelete))
+}
+
+func (enp *egressNetworkPolicyManager) handleAddUpdate(current, old interface{}, event watch.EventType) {
+	var change int
+	currentEgressNetworkPolicy, _ := current.(*osdnv1.EgressNetworkPolicy)
+
+	if event == watch.Modified {
+		oldEgressNetworkPolicy := old.(*osdnv1.EgressNetworkPolicy)
+		change = len(currentEgressNetworkPolicy.Spec.Egress) - len(oldEgressNetworkPolicy.Spec.Egress)
+	} else {
+		change = len(currentEgressNetworkPolicy.Spec.Egress)
+		enp.policyCount++
+	}
+	enp.ruleCount += change
+	enp.recordMetrics()
+}
+
+func (enp *egressNetworkPolicyManager) handleDelete(obj interface{}) {
+	egressNetworkPolicy, _ := obj.(*osdnv1.EgressNetworkPolicy)
+	enp.ruleCount -= len(egressNetworkPolicy.Spec.Egress)
+	enp.policyCount--
+	enp.recordMetrics()
+}
+
+// recordMetrics records prometheus metrics
+func (enp *egressNetworkPolicyManager) recordMetrics() {
+	metrics.RecordEgressFirewallRuleCount(float64(enp.ruleCount))
+	metrics.RecordEgressFirewallCount(float64(enp.policyCount))
+}

--- a/pkg/network/master/egress_network_policy_test.go
+++ b/pkg/network/master/egress_network_policy_test.go
@@ -1,0 +1,135 @@
+package master
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/watch"
+
+	osdnv1 "github.com/openshift/api/network/v1"
+)
+
+func Test_handleAddUpdate(t *testing.T) {
+	tests := []struct {
+		testCaseName          string
+		initialRulesCount     int
+		expectedRulesCount    int
+		initialPoliciesCount  int
+		expectedPoliciesCount int
+		current               *osdnv1.EgressNetworkPolicy
+		old                   *osdnv1.EgressNetworkPolicy
+		event                 watch.EventType
+	}{
+		{
+			testCaseName:          "should set egress rule count for add handle with non-zero rules",
+			expectedRulesCount:    3,
+			expectedPoliciesCount: 1,
+			current:               generateNPWithRules(3),
+			old:                   nil,
+			event:                 watch.Added,
+		},
+		{
+			testCaseName:          "should not alter egress rule count for add handle with zero rules",
+			expectedRulesCount:    0,
+			expectedPoliciesCount: 1,
+			current:               generateNPWithRules(0),
+			old:                   nil,
+			event:                 watch.Added,
+		},
+		{
+			testCaseName:          "should increase egress rule count for update handle with increased rules count",
+			expectedRulesCount:    1,
+			expectedPoliciesCount: 0,
+			current:               generateNPWithRules(3),
+			old:                   generateNPWithRules(2),
+			event:                 watch.Modified,
+		},
+		{
+			testCaseName:          "should not alter egress rule count for update handle with unchanged rules count",
+			expectedRulesCount:    0,
+			initialPoliciesCount:  5,
+			expectedPoliciesCount: 5,
+			current:               generateNPWithRules(0),
+			old:                   generateNPWithRules(0),
+			event:                 watch.Modified,
+		},
+		{
+			testCaseName:          "should decrease egress rule count for update handle with decreased rules count",
+			initialRulesCount:     4,
+			expectedRulesCount:    3,
+			initialPoliciesCount:  1,
+			expectedPoliciesCount: 1,
+			current:               generateNPWithRules(3),
+			old:                   generateNPWithRules(4),
+			event:                 watch.Modified,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testCaseName, func(t *testing.T) {
+			pm := newEgressNetworkPolicyManager()
+			pm.ruleCount = tc.initialRulesCount
+			pm.policyCount = tc.initialPoliciesCount
+			pm.handleAddUpdate(tc.current, tc.old, tc.event)
+			if pm.ruleCount != tc.expectedRulesCount {
+				t.Errorf("handleAddUpdate(): got %d egress network policy rules, expected %d egress network policy rules",
+					pm.ruleCount, tc.expectedRulesCount)
+			}
+			if pm.policyCount != tc.expectedPoliciesCount {
+				t.Errorf("handleAddUpdate(): got %d egress network policies, expected %d egress network policies",
+					pm.policyCount, tc.expectedPoliciesCount)
+			}
+		})
+	}
+}
+
+func Test_handleDelete(t *testing.T) {
+	tests := []struct {
+		testCaseName         string
+		initialRulesCount    int
+		expectedRulesCount   int
+		initialPoliciesCount int
+		obj                  *osdnv1.EgressNetworkPolicy
+	}{
+		{
+			testCaseName:         "should not alter egress rule count for delete handle with zero rules",
+			expectedRulesCount:   0,
+			initialPoliciesCount: 1,
+			obj:                  generateNPWithRules(0),
+		},
+		{
+			testCaseName:         "should set egress rule count for delete handle non-zero rules",
+			expectedRulesCount:   1,
+			initialPoliciesCount: 5,
+			initialRulesCount:    5,
+			obj:                  generateNPWithRules(4),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testCaseName, func(t *testing.T) {
+			pm := newEgressNetworkPolicyManager()
+			pm.ruleCount = tc.initialRulesCount
+			pm.policyCount = tc.initialPoliciesCount
+			pm.handleDelete(tc.obj)
+			if pm.ruleCount != tc.expectedRulesCount {
+				t.Errorf("handleDelete(): got %d, expected %d", pm.ruleCount, tc.expectedRulesCount)
+			}
+			if pm.policyCount != (tc.initialPoliciesCount - 1) {
+				t.Errorf("handleDelete(): got %d egress network policies, expected %d egress network policy",
+					pm.policyCount, tc.initialPoliciesCount-1)
+			}
+		})
+	}
+}
+
+func generateNPWithRules(amount int) *osdnv1.EgressNetworkPolicy {
+	prs := make([]osdnv1.EgressNetworkPolicyRule, amount)
+	for i := 0; i < amount; i++ {
+		prs[i] = osdnv1.EgressNetworkPolicyRule{}
+	}
+	return &osdnv1.EgressNetworkPolicy{
+		Spec: osdnv1.EgressNetworkPolicySpec{
+			Egress: prs,
+		},
+	}
+}

--- a/pkg/network/master/metrics/record.go
+++ b/pkg/network/master/metrics/record.go
@@ -1,0 +1,20 @@
+package metrics
+
+// contains all controller/master metric data updates
+
+// RecordEgressFirewallCount records the number of kind EgressNetworkPolicy
+func RecordEgressFirewallCount(count float64) {
+	metricEgressFirewallCount.Set(count)
+}
+
+// RecordEgressFirewallRuleCount records the number of Egress firewall rules.
+// Represents the sum of all egress rules for kind EgressNetworkPolicy.
+func RecordEgressFirewallRuleCount(count float64) {
+	metricEgressFirewallRuleCount.Set(count)
+}
+
+// RecordEgressIPCount records the number of active Egress IPs.
+// This may include multiple Egress IPs for kind EgressIP.
+func RecordEgressIPCount(count float64) {
+	metricEgressIPCount.Set(count)
+}

--- a/pkg/network/master/metrics/register.go
+++ b/pkg/network/master/metrics/register.go
@@ -1,0 +1,41 @@
+package metrics
+
+// contains all controller/master metric definitions and registration
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	metricSDNNamespace           = "sdn"
+	metricSDNSubsystemController = "controller"
+)
+
+var metricEgressIPCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: metricSDNNamespace,
+	Subsystem: metricSDNSubsystemController,
+	Name:      "num_egress_ips",
+	Help:      "The number of egress IP addresses assigned to nodes",
+})
+
+// represents kind EgressNetworkPolicy egress rules from API version network.openshift.io/v1
+var metricEgressFirewallRuleCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: metricSDNNamespace,
+	Subsystem: metricSDNSubsystemController,
+	Name:      "num_egress_firewall_rules",
+	Help:      "The number of egress firewall rules defined"},
+)
+
+// represents kind EgressNetworkPolicy from API version network.openshift.io/v1
+var metricEgressFirewallCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: metricSDNNamespace,
+	Subsystem: metricSDNSubsystemController,
+	Name:      "num_egress_firewalls",
+	Help:      "The number of egress firewall policies",
+})
+
+var registry = prometheus.NewRegistry()
+
+func register() {
+	registry.MustRegister(metricEgressIPCount)
+	registry.MustRegister(metricEgressFirewallRuleCount)
+	registry.MustRegister(metricEgressFirewallCount)
+}

--- a/pkg/network/master/metrics/server.go
+++ b/pkg/network/master/metrics/server.go
@@ -1,0 +1,51 @@
+package metrics
+
+// contains HTTP metric server for controller/master
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	shutdownTimeout = time.Millisecond * 50
+	endpoint        = "/metrics"
+	bindAddress     = "127.0.0.1:29100"
+)
+
+// StartServer registers prometheus metrics and starts HTTP server (non-blocking). Binding address maybe overridden by env variable.
+func StartServer() *http.Server {
+	register()
+	handler := promhttp.InstrumentMetricHandler(registry, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	mux := http.NewServeMux()
+	mux.Handle(endpoint, handler)
+	server := &http.Server{Addr: bindAddress, Handler: mux}
+	klog.Infof("Starting HTTP metrics server")
+
+	go func() {
+		if httpServerMessage := server.ListenAndServe(); httpServerMessage != nil && httpServerMessage != http.ErrServerClosed {
+			klog.Errorf("HTTP metrics server ended with error: %v", httpServerMessage)
+		}
+		klog.Infof("HTTP metrics server finished")
+	}()
+
+	return server
+}
+
+// StopServer attempts to shutdown the HTTP server argument.
+func StopServer(server *http.Server) {
+	if server == nil {
+		klog.Errorf("Stopping HTTP metric server failed due to nil pointer received")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if httpServerMessage := server.Shutdown(ctx); httpServerMessage != nil && httpServerMessage != http.ErrServerClosed {
+		klog.Errorf("Shutting down HTTP metrics server caused error: %v", httpServerMessage)
+	}
+}


### PR DESCRIPTION
Add an insecure HTTP metrics server that serves
metrics on loopback port 29100.

Add metrics to count egress firewalls,
egress firewall rules and egress IPs count.

In order to validate the metrics:

Metric `num_egress_ips`:
1. Configure EgressIP: https://docs.openshift.com/container-platform/4.9/networking/openshift_sdn/assigning-egress-ips.html
2. Exec into SDN pod that is the current LE leader. You can see whos the leader in a config map in the SDN namespace.
3. curl localhost:29100/metrics | grep num_egress_ips
4. You should see an integer from step 3 which represents the total number of egress IPs. This should be the same as the amount you created in step 1.

Metric `num_egress_firewall_rules`:
1. Configure EgressFirewall: https://docs.openshift.com/container-platform/4.9/networking/openshift_sdn/configuring-egress-firewall.html
2. Exec into SDN pod that is the current LE leader. You can see whos the leader in a config map in the SDN namespace.
3. curl localhost:29100/metrics | grep num_egress_firewall_rules
4. You should see an integer from step 3 which represents the total number of EgressFirewall egress rules. This should be the same as the amount you created in step 1.

Metric `num_egress_firewalls`: 
1. 1. Configure X number EgressFirewall: https://docs.openshift.com/container-platform/4.9/networking/openshift_sdn/configuring-egress-firewall.html
2. Exec into SDN pod that is the current LE leader. You can see whos the leader in a config map in the SDN namespace.
3. curl localhost:29100/metrics | grep num_egress_firewalls
4. You should see an integer from step 3 which represents the total number of EgressFirewalls. This should be the same as the amount you created in step 1.


Signed-off-by: Martin Kennelly <mkennell@redhat.com>