### PR TITLE
Metrics: Expose VxLAN interface statistics

### DIFF
--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -419,8 +419,9 @@ func (node *OsdnNode) Start() error {
 	}
 
 	go kwait.Forever(node.policy.SyncVNIDRules, time.Hour)
+	vxlanIfaceName := fmt.Sprintf("vxlan_sys_%d", node.networkInfo.VXLANPort)
 	go kwait.Forever(func() {
-		metrics.GatherPeriodicMetrics()
+		metrics.GatherPeriodicMetrics(vxlanIfaceName)
 		node.oc.ovs.UpdateOVSMetrics()
 	}, time.Minute*2)
 


### PR DESCRIPTION
The selection of metric names and labels is copied
from OVN-Kubernetes CNI in order to promote
consistency in OCP even though we only monitor one
iface.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

Note: Its ugly that I have to pass in the vxlan iface name to ```GatherPeriodicMetrics``` but I couldn't come up with a simpler pattern besides setting a global variable in metrics with the vxlan iface name but that is ugly also. Happy to hear suggestions.