### PR TITLE
Run clearInitialNodeNetworkUnavailableCondition earlier

### DIFF
--- a/pkg/network/master/subnets.go
+++ b/pkg/network/master/subnets.go
@@ -58,13 +58,13 @@ func (master *OsdnMaster) handleAddOrUpdateNode(obj, _ interface{}, eventType wa
 		return
 	}
 
+	master.clearInitialNodeNetworkUnavailableCondition(node)
+
 	if oldNodeIP, ok := master.hostSubnetNodeIPs[node.UID]; ok && (nodeIP == oldNodeIP) {
 		return
 	}
 	// Node status is frequently updated by kubelet, so log only if the above condition is not met
 	klog.V(5).Infof("Watch %s event for Node %q", eventType, node.Name)
-
-	master.clearInitialNodeNetworkUnavailableCondition(node)
 
 	err := master.addNode(node.Name, string(node.UID), nodeIP, nil)
 	if err != nil {


### PR DESCRIPTION
If we call the function after comparing of old and new node IP adresses, it may cause a failure, because execution stops
immediately if they are equal.

To ensure that the function is always executed, we need to call it before that.