### PR TITLE
Bug 1996140: Switch from core.Event to events.Event API for unidling

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -476,17 +476,18 @@ func (np *networkPolicyPlugin) skipIfTooManyFlows(policy *networkingv1.NetworkPo
 
 	switch {
 	case skip && skippedVersion != policy.ResourceVersion:
-		np.node.recorder.Eventf(npRef, corev1.EventTypeWarning,
-			"NetworkPolicySize", "TooManyFlows",
-			"This NetworkPolicy generates an extremely large number of OVS flows (%d) and so it will be ignored to prevent network degradation.", numFlows)
+		np.node.recorder.Eventf(npRef, nil, corev1.EventTypeWarning,
+			"NetworkPolicySize", "FailedToApplyNetworkPolicy",
+			"This NetworkPolicy generates an extremely large number of OVS flows (%d) and so it will be ignored "+
+				"to prevent network degradation.", numFlows)
 		np.skippedPolicies[policy.UID] = policy.ResourceVersion
 		delete(np.warnedPolicies, policy.UID)
 		klog.Warningf("Ignoring NetworkPolicy %s/%s because it generates an unreasonable number of flows (%d)",
 			policy.Namespace, policy.Name, numFlows)
 
 	case warn && warnedVersion != policy.ResourceVersion:
-		np.node.recorder.Eventf(npRef, corev1.EventTypeWarning,
-			"NetworkPolicySize", "TooManyFlows",
+		np.node.recorder.Eventf(npRef, nil, corev1.EventTypeWarning,
+			"NetworkPolicySize", "FailedToApplyNetworkPolicy",
 			"This NetworkPolicy generates a very large number of OVS flows (%d) and may degrade network performance.", numFlows)
 		np.warnedPolicies[policy.UID] = policy.ResourceVersion
 		delete(np.skippedPolicies, policy.UID)
@@ -494,8 +495,8 @@ func (np *networkPolicyPlugin) skipIfTooManyFlows(policy *networkingv1.NetworkPo
 			policy.Namespace, policy.Name, numFlows)
 
 	case !skip && !warn && (skippedVersion != "" || warnedVersion != ""):
-		np.node.recorder.Eventf(npRef, corev1.EventTypeNormal,
-			"NetworkPolicySize", "OK",
+		np.node.recorder.Eventf(npRef, nil, corev1.EventTypeNormal,
+			"NetworkPolicySize", "CreatedNetworkPolicy",
 			"This NetworkPolicy now generates an acceptable number of OVS flows.")
 		delete(np.skippedPolicies, policy.UID)
 		delete(np.warnedPolicies, policy.UID)

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/record"
+	eventsv1 "k8s.io/client-go/tools/events"
 	"k8s.io/kubernetes/pkg/util/async"
 
 	osdnv1 "github.com/openshift/api/network/v1"
@@ -1845,7 +1845,7 @@ func TestNetworkPolicyPathological(t *testing.T) {
 	np, ovsif, synced, stopCh := newTestNPP()
 	defer close(stopCh)
 
-	fakeRecorder := record.NewFakeRecorder(5)
+	fakeRecorder := eventsv1.NewFakeRecorder(5)
 	np.node.recorder = fakeRecorder
 
 	origFlows, err := ovsif.DumpFlows("")


### PR DESCRIPTION
client-go new APIs to manage k8s Event API.
This new k8 API is a departure from core's Event API.
We need to upgrade to the new API before
client-go tools remove support for core's Event
API.

In order for unidling to work, we need to upgrade openshift
controller manager to use the new Events APIs.

This patch only focuses on upgrading the Events API for
unidling and subsequent work is needed to update other
parts of this codebase to use the new Event API.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>


WIP until https://github.com/openshift/openshift-controller-manager/pull/208 merges.