### PR TITLE
Adding `--platform-type` argument

### DIFF
--- a/pkg/cmd/openshift-sdn-controller/cmd.go
+++ b/pkg/cmd/openshift-sdn-controller/cmd.go
@@ -9,6 +9,7 @@ import (
 )
 
 type OpenShiftNetworkController struct {
+	platformType string
 }
 
 func NewOpenShiftNetworkControllerCommand(name string) *cobra.Command {
@@ -31,7 +32,8 @@ func NewOpenShiftNetworkControllerCommand(name string) *cobra.Command {
 			}
 		},
 	}
-
+	flags := cmd.Flags()
+	flags.StringVar(&options.platformType, "platform-type", "", "The cloud provider platform type openshift-sdn is deployed on")
 	return cmd
 }
 
@@ -41,7 +43,7 @@ func (o *OpenShiftNetworkController) Validate() error {
 
 // StartNetworkController calls RunOpenShiftNetworkController and then waits forever
 func (o *OpenShiftNetworkController) StartNetworkController() error {
-	if err := RunOpenShiftNetworkController(); err != nil {
+	if err := RunOpenShiftNetworkController(o.platformType); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/openshift-sdn-controller/interfaces.go
+++ b/pkg/cmd/openshift-sdn-controller/interfaces.go
@@ -20,7 +20,7 @@ type controllerContext struct {
 	osdnInformers       osdninformer.SharedInformerFactory
 }
 
-func newControllerContext(clientConfig *rest.Config) (*controllerContext, error) {
+func newControllerContext(platformType string, clientConfig *rest.Config) (*controllerContext, error) {
 	kubeClient, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/openshift-sdn-controller/network_controller.go
+++ b/pkg/cmd/openshift-sdn-controller/network_controller.go
@@ -26,7 +26,7 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/version"
 )
 
-func RunOpenShiftNetworkController() error {
+func RunOpenShiftNetworkController(platformType string) error {
 	serviceability.InitLogrusFromKlog()
 
 	clientConfig, err := rest.InClusterConfig()
@@ -40,7 +40,7 @@ func RunOpenShiftNetworkController() error {
 	}
 
 	originControllerManager := func(ctx context.Context) {
-		controllerContext, err := newControllerContext(clientConfig)
+		controllerContext, err := newControllerContext(platformType, clientConfig)
 		if err != nil {
 			klog.Fatal(err)
 		}

--- a/pkg/cmd/openshift-sdn-node/cmd.go
+++ b/pkg/cmd/openshift-sdn-node/cmd.go
@@ -28,8 +28,9 @@ import (
 // openShiftSDN stores the variables needed to initialize the real networking
 // processess from the command line.
 type openShiftSDN struct {
-	nodeName string
-	nodeIP   string
+	nodeName     string
+	nodeIP       string
+	platformType string
 
 	proxyConfigFilePath string
 	proxyConfig         *kubeproxyconfig.KubeProxyConfiguration
@@ -72,6 +73,7 @@ func NewOpenShiftSDNCommand(basename string, errout io.Writer) *cobra.Command {
 	cmd.MarkFlagRequired("node-ip")
 	flags.StringVar(&sdn.proxyConfigFilePath, "proxy-config", "", "Location of the kube-proxy configuration file")
 	cmd.MarkFlagRequired("proxy-config")
+	flags.StringVar(&sdn.platformType, "platform-type", "", "The cloud provider platform type openshift-sdn is deployed on")
 
 	return cmd
 }

--- a/pkg/cmd/openshift-sdn-node/sdn.go
+++ b/pkg/cmd/openshift-sdn-node/sdn.go
@@ -23,6 +23,7 @@ func (sdn *openShiftSDN) initSDN() error {
 	sdn.osdnNode, err = sdnnode.New(&sdnnode.OsdnNodeConfig{
 		NodeName:      sdn.nodeName,
 		NodeIP:        sdn.nodeIP,
+		PlatformType:  sdn.platformType,
 		OSDNClient:    sdn.informers.osdnClient,
 		KClient:       sdn.informers.kubeClient,
 		KubeInformers: sdn.informers.kubeInformers,

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -63,8 +63,9 @@ type osdnPolicy interface {
 }
 
 type OsdnNodeConfig struct {
-	NodeName string
-	NodeIP   string
+	NodeName     string
+	NodeIP       string
+	PlatformType string
 
 	OSDNClient osdnclient.Interface
 	KClient    kubernetes.Interface


### PR DESCRIPTION
This adds a `--platform-type` argument to both openshift-sdn and openshift-sdn-controller, which is a precursor to both #378 and #365 

/assign @danwinship @abhat 