### PR TITLE
Bug 2033332: It is possible to have Networkpolicy types with no rules

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -379,10 +379,18 @@ func (np *networkPolicyPlugin) generateNamespaceFlows(otx ovs.Transaction, npns 
 			for _, flow := range npp.ingressFlows {
 				otx.AddFlow("table=80, priority=150, reg1=%d, %s actions=output:NXM_NX_REG2[]", npns.vnid, flow)
 			}
+			// the event that ingress is included in the policy type but there are no ingress rules
+			if len(npp.ingressFlows) == 0 {
+				otx.AddFlow("table=80, priority=150, reg1=%d, actions=output:NXM_NX_REG2[]", npns.vnid)
+			}
 		}
 		if npp.affectsEgress {
 			for _, flow := range npp.egressFlows {
 				otx.AddFlow("table=27, priority=150, reg0=%d, %s actions=goto_table:30", npns.vnid, flow)
+			}
+			// the event that the egress is included in the policy type but there are no egress rules
+			if len(npp.egressFlows) == 0 {
+				otx.AddFlow("table=27, priority=150, reg0=%d, actions=goto_table:30", npns.vnid)
 			}
 		}
 	}


### PR DESCRIPTION
If there is a NetworkPolicy type specified but no rules included the
namespaces vnid will have no flow for what to do for pods in that
namespace which will effectivly isolate them

change the behavior so that if there is no rule present but the policy
type is still specified that the default non-isolating rule is generated.

https://bugzilla.redhat.com/show_bug.cgi?id=2033332