### PR TITLE
[WIP] fixes flakes with networkPolicy egress upstream tests

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -340,6 +340,7 @@ func (np *networkPolicyPlugin) syncFlows() {
 	for _, ip := range np.ips {
 		// remove network isolation from pods that have been added and
 		// caused a flow recalculation
+		klog.Errorf("KEYWORD: why is maybe this invalid (%s)", ip)
 		otx.DeleteFlows("table=27, cookie=1/-1, ip, nw_src=%s", ip)
 		otx.DeleteFlows("table=80, cookie=1/-1, ip, nw_src=%s", ip)
 	}

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -1033,7 +1033,7 @@ func (np *networkPolicyPlugin) refreshPodNetworkPolicies(pod *corev1.Pod) {
 	for _, npns := range np.namespaces {
 		for _, npp := range npns.policies {
 			if (npp.watchesOwnPods && npns == podNs) || npp.watchesAllPods {
-				if !podNeedsSync {
+				if !podNeedsSync && len(pod.Status.PodIP) > 0 {
 					np.ips = append(np.ips, pod.Status.PodIP)
 					podNeedsSync = true
 				}


### PR DESCRIPTION
attempts to add NetworkPolicy Egress tests in origin PR
https://github.com/openshift/origin/pull/26647 are flaky because of
assumptions made about when it is safe to unisolate pods new pods that
existing networkPolicies apply to

Because the syncFlows() is rate limited it is not safe to assume that
all flows are synced when returning from np.refreshPodNetworkPolicies().
This PR changes how the flows that restrict new pods are removed by
removing the isolating flows as part of syncFlows if a recalulation is
required.