### PR TITLE
Bug 2039294: SDN controller metrics cannot be scraped by prometheus

### DIFF
--- a/pkg/cmd/openshift-sdn-controller/network_controller.go
+++ b/pkg/cmd/openshift-sdn-controller/network_controller.go
@@ -2,7 +2,6 @@ package openshift_sdn_controller
 
 import (
 	"context"
-	"net/http"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -81,7 +80,7 @@ func RunOpenShiftNetworkController(platformType string) error {
 	if err != nil {
 		return err
 	}
-	var metricsServer *http.Server
+	metricsServer := metrics.StartServer()
 	go leaderelection.RunOrDie(context.Background(),
 		leaderelection.LeaderElectionConfig{
 			Lock:          rl,
@@ -90,7 +89,7 @@ func RunOpenShiftNetworkController(platformType string) error {
 			RetryPeriod:   leaderConfig.RetryPeriod.Duration,
 			Callbacks: leaderelection.LeaderCallbacks{
 				OnStartedLeading: func(ctx context.Context) {
-					metricsServer = metrics.StartServer()
+					metrics.Register()
 					originControllerManager(ctx)
 				},
 				OnStoppedLeading: func() {

--- a/pkg/network/master/metrics/register.go
+++ b/pkg/network/master/metrics/register.go
@@ -34,7 +34,7 @@ var metricEgressFirewallCount = prometheus.NewGauge(prometheus.GaugeOpts{
 
 var registry = prometheus.NewRegistry()
 
-func register() {
+func Register() {
 	registry.MustRegister(metricEgressIPCount)
 	registry.MustRegister(metricEgressFirewallRuleCount)
 	registry.MustRegister(metricEgressFirewallCount)

--- a/pkg/network/master/metrics/server.go
+++ b/pkg/network/master/metrics/server.go
@@ -20,7 +20,6 @@ const (
 
 // StartServer registers prometheus metrics and starts HTTP server (non-blocking). Binding address maybe overridden by env variable.
 func StartServer() *http.Server {
-	register()
 	handler := promhttp.InstrumentMetricHandler(registry, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	mux := http.NewServeMux()
 	mux.Handle(endpoint, handler)


### PR DESCRIPTION
Non-leader SDN controller instances do not expose a metrics endpoint.
This causes prometheus to generate an error when attempting to
scrape non-leader SDN controller metrics with a 5XX HTTP error code.
Leader SDN controller metrics are successfully scraped but the
error is unacceptable for non-leader instances.

This PR starts the server for all SDN controller instances but only
the leader instance registers SDN controller specific metrics.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>

A PR in CNO is currently under review to add the `servicemonitor`: https://github.com/openshift/cluster-network-operator/pull/1250

/cc @danwinship 