### PR TITLE
Bug 2038793: Use the kubeClient instead of the informer cache to fetch nodes for egress IP validation.

### DIFF
--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -10,7 +10,6 @@ import (
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
-	kubeinformers "k8s.io/client-go/informers"
 	fakekubeclient "k8s.io/client-go/kubernetes/fake"
 
 	osdnv1 "github.com/openshift/api/network/v1"
@@ -1386,12 +1385,7 @@ func TestAutomaticEgressAllocationRespectingCapacityAndNamespaceBalancingWithFul
 	node2Name, node2IP, node2Capacity := "node2", "172.17.0.2", 1
 	egressIP1, egressIP2, egressIP3 := "172.17.0.101", "172.17.0.102", "172.17.0.103"
 
-	fClient := fakekubeclient.NewSimpleClientset()
-	kubeInformer := kubeinformers.NewSharedInformerFactory(fClient, 0)
-	nodeInformer := kubeInformer.Core().V1().Nodes()
-
-	nodeStore := nodeInformer.Informer().GetStore()
-	nodeStore.Add(&corev1.Node{
+	node1 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node1Name,
 			Annotations: map[string]string{
@@ -1406,8 +1400,8 @@ func TestAutomaticEgressAllocationRespectingCapacityAndNamespaceBalancingWithFul
 				},
 			},
 		},
-	})
-	nodeStore.Add(&corev1.Node{
+	}
+	node2 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node2Name,
 			Annotations: map[string]string{
@@ -1422,10 +1416,11 @@ func TestAutomaticEgressAllocationRespectingCapacityAndNamespaceBalancingWithFul
 				},
 			},
 		},
-	})
+	}
 
+	fClient := fakekubeclient.NewSimpleClientset(node1, node2)
 	eit, _ := setupEgressIPTracker(t, true)
-	eit.nodeInformer = nodeInformer
+	eit.kubeClient = fClient
 
 	updateHostSubnetEgress(eit, &osdnv1.HostSubnet{
 		Host:        node1Name,
@@ -1470,12 +1465,7 @@ func TestAutomaticEgressAllocationRespectingCapacityAndBalancedNamespaceAssignme
 	node3Name, node3IP, node3Capacity := "node3", "172.17.0.3", 1
 	egressIP1, egressIP2, egressIP3, egressIP4, egressIP5, egressIP6 := "172.17.0.101", "172.17.0.102", "172.17.0.103", "172.17.0.104", "172.17.0.105", "172.17.0.106"
 
-	fClient := fakekubeclient.NewSimpleClientset()
-	kubeInformer := kubeinformers.NewSharedInformerFactory(fClient, 0)
-	nodeInformer := kubeInformer.Core().V1().Nodes()
-
-	nodeStore := nodeInformer.Informer().GetStore()
-	nodeStore.Add(&corev1.Node{
+	node1 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node1Name,
 			Annotations: map[string]string{
@@ -1490,8 +1480,8 @@ func TestAutomaticEgressAllocationRespectingCapacityAndBalancedNamespaceAssignme
 				},
 			},
 		},
-	})
-	nodeStore.Add(&corev1.Node{
+	}
+	node2 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node2Name,
 			Annotations: map[string]string{
@@ -1506,8 +1496,8 @@ func TestAutomaticEgressAllocationRespectingCapacityAndBalancedNamespaceAssignme
 				},
 			},
 		},
-	})
-	nodeStore.Add(&corev1.Node{
+	}
+	node3 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node3Name,
 			Annotations: map[string]string{
@@ -1522,10 +1512,12 @@ func TestAutomaticEgressAllocationRespectingCapacityAndBalancedNamespaceAssignme
 				},
 			},
 		},
-	})
+	}
+
+	fClient := fakekubeclient.NewSimpleClientset(node1, node2, node3)
 
 	eit, _ := setupEgressIPTracker(t, true)
-	eit.nodeInformer = nodeInformer
+	eit.kubeClient = fClient
 
 	updateHostSubnetEgress(eit, &osdnv1.HostSubnet{
 		Host:        node1Name,
@@ -1593,12 +1585,7 @@ func TestAutomaticEgressAllocationRespectingCapacityAndBalancedNamespaceAssignme
 	node3Name, node3IP, node3Capacity := "node3", "172.17.0.3", 1
 	egressIP1, egressIP2, egressIP3, egressIP4, egressIP5, egressIP6 := "172.17.0.101", "172.17.0.102", "172.17.0.103", "172.17.0.104", "172.17.0.105", "172.17.0.106"
 
-	fClient := fakekubeclient.NewSimpleClientset()
-	kubeInformer := kubeinformers.NewSharedInformerFactory(fClient, 0)
-	nodeInformer := kubeInformer.Core().V1().Nodes()
-
-	nodeStore := nodeInformer.Informer().GetStore()
-	nodeStore.Add(&corev1.Node{
+	node1 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node1Name,
 			Annotations: map[string]string{
@@ -1613,8 +1600,8 @@ func TestAutomaticEgressAllocationRespectingCapacityAndBalancedNamespaceAssignme
 				},
 			},
 		},
-	})
-	nodeStore.Add(&corev1.Node{
+	}
+	node2 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node2Name,
 			Annotations: map[string]string{
@@ -1629,8 +1616,8 @@ func TestAutomaticEgressAllocationRespectingCapacityAndBalancedNamespaceAssignme
 				},
 			},
 		},
-	})
-	nodeStore.Add(&corev1.Node{
+	}
+	node3 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node3Name,
 			Annotations: map[string]string{
@@ -1645,10 +1632,12 @@ func TestAutomaticEgressAllocationRespectingCapacityAndBalancedNamespaceAssignme
 				},
 			},
 		},
-	})
+	}
+
+	fClient := fakekubeclient.NewSimpleClientset(node1, node2, node3)
 
 	eit, _ := setupEgressIPTracker(t, true)
-	eit.nodeInformer = nodeInformer
+	eit.kubeClient = fClient
 
 	updateHostSubnetEgress(eit, &osdnv1.HostSubnet{
 		Host:        node1Name,
@@ -1710,12 +1699,7 @@ func TestAutomaticEgressAllocationRespectingCapacityAndConsistentFullGlobalAssig
 	node2Name, node2IP, node2Capacity := "node2", "172.17.0.2", 1
 	egressIP1, egressIP2, egressIP3, egressIP4, egressIP5 := "172.17.0.101", "172.17.0.102", "172.17.0.103", "172.17.0.104", "172.17.0.105"
 
-	fClient := fakekubeclient.NewSimpleClientset()
-	kubeInformer := kubeinformers.NewSharedInformerFactory(fClient, 0)
-	nodeInformer := kubeInformer.Core().V1().Nodes()
-
-	nodeStore := nodeInformer.Informer().GetStore()
-	nodeStore.Add(&corev1.Node{
+	node1 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node1Name,
 			Annotations: map[string]string{
@@ -1730,8 +1714,8 @@ func TestAutomaticEgressAllocationRespectingCapacityAndConsistentFullGlobalAssig
 				},
 			},
 		},
-	})
-	nodeStore.Add(&corev1.Node{
+	}
+	node2 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node2Name,
 			Annotations: map[string]string{
@@ -1746,10 +1730,11 @@ func TestAutomaticEgressAllocationRespectingCapacityAndConsistentFullGlobalAssig
 				},
 			},
 		},
-	})
+	}
 
+	fClient := fakekubeclient.NewSimpleClientset(node1, node2)
 	eit, _ := setupEgressIPTracker(t, true)
-	eit.nodeInformer = nodeInformer
+	eit.kubeClient = fClient
 
 	updateHostSubnetEgress(eit, &osdnv1.HostSubnet{
 		Host:        node1Name,
@@ -1865,12 +1850,7 @@ func TestAutomaticEgressAllocationRespectingAvailability(t *testing.T) {
 	node2Name, node2IP, node2Capacity := "node2", "172.17.0.2", 6
 	egressIP1, egressIP2, egressIP3, egressIP4, egressIP5, egressIP6 := "172.17.0.55", "172.17.0.56", "172.17.0.57", "172.17.0.58", "172.17.0.59", "172.17.0.5"
 
-	fClient := fakekubeclient.NewSimpleClientset()
-	kubeInformer := kubeinformers.NewSharedInformerFactory(fClient, 0)
-	nodeInformer := kubeInformer.Core().V1().Nodes()
-
-	nodeStore := nodeInformer.Informer().GetStore()
-	nodeStore.Add(&corev1.Node{
+	node1 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node1Name,
 			Annotations: map[string]string{
@@ -1885,8 +1865,8 @@ func TestAutomaticEgressAllocationRespectingAvailability(t *testing.T) {
 				},
 			},
 		},
-	})
-	nodeStore.Add(&corev1.Node{
+	}
+	node2 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node2Name,
 			Annotations: map[string]string{
@@ -1901,10 +1881,12 @@ func TestAutomaticEgressAllocationRespectingAvailability(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
+
+	fClient := fakekubeclient.NewSimpleClientset(node1, node2)
 
 	eit, _ := setupEgressIPTracker(t, true)
-	eit.nodeInformer = nodeInformer
+	eit.kubeClient = fClient
 
 	updateHostSubnetEgress(eit, &osdnv1.HostSubnet{
 		Host:        node1Name,
@@ -1980,12 +1962,7 @@ func TestManualEgressAllocationRespectingCapacity(t *testing.T) {
 	node1Name, node1IP, node1Capacity := "node1", "172.17.0.1", 2
 	node2Name, node2IP, node2Capacity := "node2", "172.17.0.2", 1
 
-	fClient := fakekubeclient.NewSimpleClientset()
-	kubeInformer := kubeinformers.NewSharedInformerFactory(fClient, 0)
-	nodeInformer := kubeInformer.Core().V1().Nodes()
-
-	nodeStore := nodeInformer.Informer().GetStore()
-	nodeStore.Add(&corev1.Node{
+	node1 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node1Name,
 			Annotations: map[string]string{
@@ -2000,8 +1977,8 @@ func TestManualEgressAllocationRespectingCapacity(t *testing.T) {
 				},
 			},
 		},
-	})
-	nodeStore.Add(&corev1.Node{
+	}
+	node2 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node2Name,
 			Annotations: map[string]string{
@@ -2016,10 +1993,11 @@ func TestManualEgressAllocationRespectingCapacity(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
+	fClient := fakekubeclient.NewSimpleClientset(node1, node2)
 
 	eit, w := setupEgressIPTracker(t, true)
-	eit.nodeInformer = nodeInformer
+	eit.kubeClient = fClient
 
 	updateHostSubnetEgress(eit, &osdnv1.HostSubnet{
 		Host:        node1Name,
@@ -2138,12 +2116,7 @@ func TestManualEgressAllocationRespectingCapacity(t *testing.T) {
 func TestValidEgressCIDRsForCloudNodes(t *testing.T) {
 	node1Name, node1IP, node1Capacity := "node1", "172.17.0.1", 2
 
-	fClient := fakekubeclient.NewSimpleClientset()
-	kubeInformer := kubeinformers.NewSharedInformerFactory(fClient, 0)
-	nodeInformer := kubeInformer.Core().V1().Nodes()
-
-	nodeStore := nodeInformer.Informer().GetStore()
-	nodeStore.Add(&corev1.Node{
+	node1 := &corev1.Node{
 		ObjectMeta: v1.ObjectMeta{
 			Name: node1Name,
 			Annotations: map[string]string{
@@ -2158,10 +2131,12 @@ func TestValidEgressCIDRsForCloudNodes(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
+
+	fClient := fakekubeclient.NewSimpleClientset(node1)
 
 	eit, _ := setupEgressIPTracker(t, true)
-	eit.nodeInformer = nodeInformer
+	eit.kubeClient = fClient
 
 	// Fully within the cloud network, no error
 	err := eit.validateEgressCIDRsAreSubnetOfCloudNetwork(&osdnv1.HostSubnet{

--- a/pkg/network/master/egressip.go
+++ b/pkg/network/master/egressip.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	kcoreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 
 	cloudnetworkclient "github.com/openshift/client-go/cloudnetwork/clientset/versioned"
@@ -58,7 +59,8 @@ func newEgressIPManager(cloudEgressIP bool) *egressIPManager {
 	return eim
 }
 
-func (eim *egressIPManager) Start(osdnClient osdnclient.Interface,
+func (eim *egressIPManager) Start(kubeClient kubernetes.Interface,
+	osdnClient osdnclient.Interface,
 	cloudNetworkClient cloudnetworkclient.Interface,
 	cloudPrivateIPConfigInformer cloudnetworkinformerv1.CloudPrivateIPConfigInformer,
 	hostSubnetInformer osdninformers.HostSubnetInformer,
@@ -74,11 +76,11 @@ func (eim *egressIPManager) Start(osdnClient osdnclient.Interface,
 		eim.cloudPrivateIPConfigInformer = cloudPrivateIPConfigInformer
 		eim.cloudPrivateIPConfigCreationQueue = make(map[string]osdcnv1.CloudPrivateIPConfig)
 		eim.watchCloudPrivateIPConfig(cloudPrivateIPConfigInformer)
-		eim.tracker.Start(hostSubnetInformer, netNamespaceInformer, nodeInformer)
+		eim.tracker.Start(kubeClient, hostSubnetInformer, netNamespaceInformer, nodeInformer)
 		return
 	}
 
-	eim.tracker.Start(hostSubnetInformer, netNamespaceInformer, nil)
+	eim.tracker.Start(nil, hostSubnetInformer, netNamespaceInformer, nil)
 }
 
 func (eim *egressIPManager) watchCloudPrivateIPConfig(cloudPrivateIPConfigInformer cloudnetworkinformerv1.CloudPrivateIPConfigInformer) {

--- a/pkg/network/master/master.go
+++ b/pkg/network/master/master.go
@@ -134,7 +134,7 @@ func (master *OsdnMaster) startSubSystems(pluginName string) {
 	}
 
 	eim := newEgressIPManager(master.cloudNetworkClient != nil)
-	eim.Start(master.osdnClient, master.cloudNetworkClient, master.cloudPrivateIPConfigInformer, master.hostSubnetInformer, master.netNamespaceInformer, master.nodeInformer)
+	eim.Start(master.kClient, master.osdnClient, master.cloudNetworkClient, master.cloudPrivateIPConfigInformer, master.hostSubnetInformer, master.netNamespaceInformer, master.nodeInformer)
 	enp := newEgressNetworkPolicyManager()
 	enp.start(master.egressNetPolInformer)
 }

--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -73,12 +74,12 @@ func newEgressIPWatcher(oc *ovsController, cloudEgressIP bool, localIP string, m
 	return eip
 }
 
-func (eip *egressIPWatcher) Start(osdnInformers osdninformers.SharedInformerFactory, kubeInformers informers.SharedInformerFactory, iptables *NodeIPTables) error {
+func (eip *egressIPWatcher) Start(osdnInformers osdninformers.SharedInformerFactory, kubeInformers informers.SharedInformerFactory, kubeClient kubernetes.Interface, iptables *NodeIPTables) error {
 	eip.iptables = iptables
 	if eip.tracker.CloudEgressIP {
-		eip.tracker.Start(osdnInformers.Network().V1().HostSubnets(), osdnInformers.Network().V1().NetNamespaces(), kubeInformers.Core().V1().Nodes())
+		eip.tracker.Start(kubeClient, osdnInformers.Network().V1().HostSubnets(), osdnInformers.Network().V1().NetNamespaces(), kubeInformers.Core().V1().Nodes())
 	} else {
-		eip.tracker.Start(osdnInformers.Network().V1().HostSubnets(), osdnInformers.Network().V1().NetNamespaces(), nil)
+		eip.tracker.Start(kubeClient, osdnInformers.Network().V1().HostSubnets(), osdnInformers.Network().V1().NetNamespaces(), nil)
 	}
 	return nil
 }

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -399,7 +399,7 @@ func (node *OsdnNode) Start() error {
 		if err := node.SetupEgressNetworkPolicy(); err != nil {
 			return err
 		}
-		if err := node.egressIP.Start(node.osdnInformers, node.kubeInformers, node.nodeIPTables); err != nil {
+		if err := node.egressIP.Start(node.osdnInformers, node.kubeInformers, node.kClient, node.nodeIPTables); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When validating the .egressIPs defined on a hostSubnet we were using
the informer cache to retrieve the node object and validate that the
egress IP is correctly defined on the cloud subnet. However, the node
informer cache is not guaranteed to be warm when the hostSubnet
informers start, which leads to race events and in case the hostSubnet
informer does not find the node object: a removal of a valid egress IP.

I investigated if there's a way to use WaitForCacheSync as to ensure
that the node informer cache is warm before the hostSubnet informer
starts, however due to the "legacy nature" which openshift-sdn employs
to start its controllers I found the task rather convoluted. Hence, the
solution used in this PR is just to use the kubeClient to fetch the
nodes.