### PR TITLE
this fixes the problem that the proxy uses the wrong src IP (not the Node IP)

### DIFF
--- a/pkg/cmd/openshift-sdn-node/kube_proxy.go
+++ b/pkg/cmd/openshift-sdn-node/kube_proxy.go
@@ -2,14 +2,13 @@ package openshift_sdn_node
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"time"
 
 	// In this file we use the import names that the upstream kube-proxy code uses.
 	// eg, "v1", "wait" rather than "corev1", "utilwait".
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -152,7 +151,7 @@ func newProxyServer(config *kubeproxyconfig.KubeProxyConfiguration, client clien
 
 		proxier, err = userspace.NewProxier(
 			userspace.NewLoadBalancerRR(),
-			net.ParseIP(config.BindAddress),
+			nodeIP,
 			iptInterface,
 			execer,
 			*utilnet.ParsePortRangeOrDie(config.PortRange),

--- a/pkg/cmd/openshift-sdn-node/proxy.go
+++ b/pkg/cmd/openshift-sdn-node/proxy.go
@@ -83,10 +83,13 @@ func (sdn *openShiftSDN) wrapProxy(s *ProxyServer, waitChan chan<- bool) error {
 		unidlingBroadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: sdn.informers.kubeClient.CoreV1().Events("")})
 		unidlingRecorder := unidlingBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "kube-proxy", Host: sdn.nodeName})
 
+		nodeIP := detectNodeIP(sdn.proxyConfig, sdn.nodeIP)
+		klog.Infof("Detected node IP %s", nodeIP.String())
+
 		signaler := unidler.NewEventSignaler(unidlingRecorder)
 		unidlingProxy, err = unidler.NewUnidlerProxier(
 			userspace.NewLoadBalancerRR(),
-			net.ParseIP(sdn.proxyConfig.BindAddress),
+			nodeIP,
 			s.IptInterface,
 			s.execer,
 			*utilnet.ParsePortRangeOrDie(sdn.proxyConfig.PortRange),


### PR DESCRIPTION
In our setup we had the problem that the `Detected node IP` where working correct but the `userspace` `NewProxier` and `NewCustomProxier` where running a other detection which failed to get the correct nodeIP.

before:

```
2022-01-20T13:19:32.961531493Z stderr F E0120 13:19:32.961241 2716479 node.go:437] Error validating node MTU: could not retrieve link id 0 while validating MTU
2022-01-20T13:19:32.961970407Z stderr F I0120 13:19:32.961875 2716479 kube_proxy.go:85] Detected node IP 100.64.64.5
2022-01-20T13:19:32.966691498Z stderr F I0120 13:19:32.966486 2716479 kube_proxy.go:116] kube-proxy running in single-stack IPv4 mode
2022-01-20T13:19:32.966726131Z stderr F I0120 13:19:32.966563 2716479 kube_proxy.go:119] Using iptables Proxier.
2022-01-20T13:19:32.966962175Z stderr F I0120 13:19:32.966860 2716479 proxier.go:293] "Using iptables mark for masquerade" ipFamily=IPv4 mark="0x00000001"
2022-01-20T13:19:32.967067639Z stderr F I0120 13:19:32.966965 2716479 proxier.go:339] "Iptables sync params" ipFamily=IPv4 minSyncPeriod="1s" syncPeriod="30s" burstSyncs=2
2022-01-20T13:19:32.967200128Z stderr F I0120 13:19:32.967068 2716479 proxier.go:349] "Iptables supports --random-fully" ipFamily=IPv4
2022-01-20T13:19:32.970506272Z stderr F I0120 13:19:32.970237 2716479 networkpolicy.go:487] SyncVNIDRules: 0 unused VNIDs
2022-01-20T13:19:32.972018837Z stderr F I0120 13:19:32.971780 2716479 proxier.go:247] "Setting proxy IP and initializing iptables" ip="100.64.40.6"
```

with the fix:
```
2022-01-20T14:08:20.414696852Z stderr F E0120 14:08:20.414551 2807070 node.go:437] Error validating node MTU: could not retrieve link id 0 while validating MTU
2022-01-20T14:08:20.414704099Z stderr F I0120 14:08:20.414604 2807070 kube_proxy.go:85] Detected node IP 100.64.64.6
2022-01-20T14:08:20.419521327Z stderr F I0120 14:08:20.419292 2807070 kube_proxy.go:116] kube-proxy running in single-stack IPv4 mode
2022-01-20T14:08:20.419562348Z stderr F I0120 14:08:20.419366 2807070 kube_proxy.go:119] Using iptables Proxier.
2022-01-20T14:08:20.419685698Z stderr F I0120 14:08:20.419605 2807070 proxier.go:293] "Using iptables mark for masquerade" ipFamily=IPv4 mark="0x00000001"
2022-01-20T14:08:20.419718862Z stderr F I0120 14:08:20.419687 2807070 proxier.go:339] "Iptables sync params" ipFamily=IPv4 minSyncPeriod="1s" syncPeriod="30s" burstSyncs=2
2022-01-20T14:08:20.419816297Z stderr F I0120 14:08:20.419760 2807070 proxier.go:349] "Iptables supports --random-fully" ipFamily=IPv4
2022-01-20T14:08:20.420195039Z stderr F I0120 14:08:20.420118 2807070 proxy.go:87] Detected node IP 100.64.64.5
2022-01-20T14:08:20.420274962Z stderr F I0120 14:08:20.420220 2807070 proxier.go:247] "Setting proxy IP and initializing iptables" ip="100.64.64.6"
```