### PR TITLE
Bug 2060553: another fix for mixed ingress and egress policies

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -406,10 +406,10 @@ func (np *networkPolicyPlugin) generateNamespaceFlows(otx ovs.Transaction, npns 
 			for _, ip := range npp.selectedIPs {
 				if !selectedIPs.Has(ip) {
 					selectedIPs.Insert(ip)
-					if hasIngressPolicies && !allPodsIsolatedForIngress {
+					if npp.affectsIngress && !allPodsIsolatedForIngress {
 						otx.AddFlow("table=80, priority=100, reg1=%d, ip, nw_dst=%s, actions=drop", npns.vnid, ip)
 					}
-					if hasEgressPolicies && !allPodsIsolatedForEgress {
+					if npp.affectsEgress && !allPodsIsolatedForEgress {
 						otx.AddFlow("table=27, priority=100, reg0=%d, ip, nw_src=%s, actions=drop", npns.vnid, ip)
 					}
 				}


### PR DESCRIPTION
The previous fix was incomplete; it covered the case of "some policy isolates all pods for ingress and another policy selects random pods for egress and as a result all pods end up mistakenly isolated for egress", but it didn't cover "some policy isolates _some_ pods for ingress and another policy selects random pods for egress and as a result _some_ pods end up mistakenly isolated for egress".

Confirmed that the new unit tests fails without this fix.