### PR TITLE
Bug 2061919: Fix releasing egress IP in cloud environments

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -370,7 +370,7 @@ func (eip *egressIPWatcher) releaseEgressIP(egressIP, mark string) error {
 		return nil
 	}
 
-	localEgressLink, localEgressNet, _, err := eip.getEgressLinkDetails()
+	localEgressLink, localEgressNet, err := GetLinkDetails(eip.localIP)
 	if err != nil {
 		return fmt.Errorf("unable to get egress link details: %v", err)
 	}


### PR DESCRIPTION
getEgressLinkDetails uses GetNodeNameByNodeIP to get the egress IP cloud config.
This can fail if egress IP is removed by clearing EgressIPs and EgressCIDRs in HostSubnet since nodesByNodeIP entry will get removed before ReleaseEgressIP is called.
Revert to using GetLinkDetails(eip.localIP) as the additional output of getEgressLinkDetails was ignored anyway.

Signed-off-by: Patryk Diak <pdiak@redhat.com>