### PR TITLE
Bug 2052332: use pods cache during reattach processing 

### DIFF
--- a/pkg/cmd/openshift-sdn-node/cmd.go
+++ b/pkg/cmd/openshift-sdn-node/cmd.go
@@ -174,8 +174,7 @@ func (sdn *openShiftSDN) start(stopCh <-chan struct{}) error {
 	klog.Infof("Starting node networking (%s)", version.Get().String())
 
 	serviceability.StartProfiler()
-	err := sdn.runSDN()
-	if err != nil {
+	if err := sdn.runSDN(); err != nil {
 		return err
 	}
 	proxyInitChan := make(chan bool)

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -67,7 +67,8 @@ type podManager struct {
 
 	// Things only accessed through the processCNIRequests() goroutine
 	// and thus can be set from Start()
-	ipamConfig []byte
+	ipamConfig   []byte
+	reattachPods map[string]*corev1.Pod
 }
 
 // Creates a new live podManager; used by node code0
@@ -85,8 +86,9 @@ func newPodManager(kClient kubernetes.Interface, policy osdnPolicy, overlayMTU u
 // Creates a new basic podManager; used by testcases
 func newDefaultPodManager() *podManager {
 	return &podManager{
-		runningPods: make(map[string]*runningPod),
-		requests:    make(chan *cniserver.PodRequest, 20),
+		runningPods:  make(map[string]*runningPod),
+		requests:     make(chan *cniserver.PodRequest, 20),
+		reattachPods: make(map[string]*corev1.Pod),
 	}
 }
 
@@ -203,6 +205,19 @@ func getPodKey(namespace, name string) string {
 
 func (m *podManager) getPod(request *cniserver.PodRequest) *runningPod {
 	return m.runningPods[getPodKey(request.PodNamespace, request.PodName)]
+}
+
+// Add pods to Pod Manager reattach pod cache
+func (m *podManager) setReattachPodsCache(pods []*corev1.Pod) {
+	for _, pod := range pods {
+		pKey := getPodKey(pod.Namespace, pod.Name)
+		m.reattachPods[pKey] = pod
+	}
+}
+
+// Delete the Pod Manager reattach pods cache
+func (m *podManager) clearReattachPodsCache() {
+	m.reattachPods = make(map[string]*corev1.Pod)
 }
 
 // Add a request to the podManager CNI request queue
@@ -470,7 +485,8 @@ func podIsExited(p *kcontainer.Pod) bool {
 // Set up all networking (host/container veth, OVS flows, IPAM, loopback, etc)
 func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *runningPod, error) {
 	defer metrics.PodOperationsLatency.WithLabelValues(metrics.PodOperationSetup).Observe(metrics.SinceInMicroseconds(time.Now()))
-
+	var v1Pod *corev1.Pod
+	var err error
 	// Release any IPAM allocations if the setup failed
 	var success bool
 	defer func() {
@@ -478,10 +494,11 @@ func (m *podManager) setup(req *cniserver.PodRequest) (cnitypes.Result, *running
 			m.ipamDel(req.SandboxID)
 		}
 	}()
-
-	v1Pod, err := m.kClient.CoreV1().Pods(req.PodNamespace).Get(context.TODO(), req.PodName, metav1.GetOptions{})
-	if err != nil {
-		return nil, nil, err
+	pKey := getPodKey(req.PodNamespace, req.PodName)
+	if v1Pod, success = m.reattachPods[pKey]; !success {
+		if v1Pod, err = m.kClient.CoreV1().Pods(req.PodNamespace).Get(context.TODO(), req.PodName, metav1.GetOptions{}); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	var ipamResult cnitypes.Result


### PR DESCRIPTION
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
test results
```
OCP 4.9 image:
 
******************sdn-84zqg*************
Plugin Start: 17:28:15.680695
Plugin Ready: 17:28:20.678844
Time diff(s): 5
******************sdn-j6wpf*************
Plugin Start: 17:28:16.139822
Plugin Ready: 17:29:43.829619
Time diff(s): 87
******************sdn-qnjmf*************
Plugin Start: 17:30:57.958794
Plugin Ready: 17:32:12.226418
Time diff(s): 75
******************sdn-qnqdg*************
Plugin Start: 17:33:07.827914
Plugin Ready: 17:34:27.394670
Time diff(s): 80
******************sdn-qz2gm*************
Plugin Start: 17:30:11.963915
Plugin Ready: 17:30:24.910544
Time diff(s): 13
******************sdn-z87rs*************
Plugin Start: 17:28:31.051204
Plugin Ready: 17:28:56.230275
Time diff(s): 25
 
 
Clean informer image:
******************sdn-75mnp*************
Plugin Start: 17:42:13.157691
Plugin Ready: 17:42:19.850444
Time diff(s): 6
******************sdn-7c5q8*************
Plugin Start: 17:40:03.401974
Plugin Ready: 17:40:38.659059
Time diff(s): 35
******************sdn-bjjl5*************
Plugin Start: 17:42:57.667644
Plugin Ready: 17:43:03.719098
Time diff(s): 6
******************sdn-df5kk*************
Plugin Start: 17:36:11.333512
Plugin Ready: 17:36:41.379830
Time diff(s): 30
******************sdn-hbgmj*************
Plugin Start: 17:38:06.244015
Plugin Ready: 17:38:40.667368
Time diff(s): 34
******************sdn-z2qzk*************
Plugin Start: 17:43:43.855341
Plugin Ready: 17:43:50.133778
Time diff(s): 7
```
