### PR TITLE
Bug 2063123: Remove node-tainting for too-small MTU

### DIFF
--- a/pkg/cmd/openshift-sdn-cni/openshift-sdn.go
+++ b/pkg/cmd/openshift-sdn-cni/openshift-sdn.go
@@ -145,7 +145,7 @@ func (p *cniPlugin) CmdAdd(args *skel.CmdArgs) error {
 
 	var hostVeth, contVeth net.Interface
 	err = ns.WithNetNSPath(args.Netns, func(hostNS ns.NetNS) error {
-		hostVeth, contVeth, err = ip.SetupVeth(args.IfName, int(config.MTU), hostNS)
+		hostVeth, contVeth, err = ip.SetupVeth(args.IfName, int(config.OverlayMTU), hostNS)
 		if err != nil {
 			return fmt.Errorf("failed to create container veth: %v", err)
 		}

--- a/pkg/cmd/openshift-sdn-cni/openshift-sdn_test.go
+++ b/pkg/cmd/openshift-sdn-cni/openshift-sdn_test.go
@@ -82,7 +82,7 @@ func TestOpenshiftSdnCNIPlugin(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	path := filepath.Join(tmpDir, cniserver.CNIServerSocketName)
-	server := cniserver.NewCNIServer(tmpDir, &cniserver.Config{MTU: 1500})
+	server := cniserver.NewCNIServer(tmpDir, &cniserver.Config{OverlayMTU: 1500})
 	if err := server.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}

--- a/pkg/cmd/openshift-sdn-node/cmd.go
+++ b/pkg/cmd/openshift-sdn-node/cmd.go
@@ -278,7 +278,7 @@ func readMTUOverride(file string) (uint32, uint32, error) {
 	}
 
 	conf := struct {
-		MTU         uint32 `json:"mtu"`
+		OverlayMTU  uint32 `json:"mtu"`
 		RoutableMTU uint32 `json:"routable-mtu"`
 	}{}
 	err = yaml.Unmarshal(bytes, &conf)
@@ -286,5 +286,5 @@ func readMTUOverride(file string) (uint32, uint32, error) {
 		return 0, 0, err
 	}
 
-	return conf.MTU, conf.RoutableMTU, err
+	return conf.OverlayMTU, conf.RoutableMTU, err
 }

--- a/pkg/network/common/cniserver/cniserver.go
+++ b/pkg/network/common/cniserver/cniserver.go
@@ -54,7 +54,7 @@ const CNIServerConfigFilePath string = CNIServerRunDir + "/" + CNIServerConfigFi
 
 // Server-to-plugin config data
 type Config struct {
-	MTU          uint32 `json:"mtu"`
+	OverlayMTU   uint32 `json:"mtu"`
 	RoutableMTU  uint32 `json:"routableMTU,omitempty"`
 	PlatformType string `json:"platformType,omitempty"`
 }

--- a/pkg/network/common/cniserver/cniserver_test.go
+++ b/pkg/network/common/cniserver/cniserver_test.go
@@ -60,7 +60,7 @@ func TestCNIServer(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 	socketPath := filepath.Join(tmpDir, CNIServerSocketName)
 
-	s := NewCNIServer(tmpDir, &Config{MTU: 1500})
+	s := NewCNIServer(tmpDir, &Config{OverlayMTU: 1500})
 	if err := s.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestCNIServerDirectory(t *testing.T) {
 
 	// If the rundir doesn't exist, it will create it, with the correct permissions
 	runDir := filepath.Join(tmpDir, "1")
-	s := NewCNIServer(runDir, &Config{MTU: 1500})
+	s := NewCNIServer(runDir, &Config{OverlayMTU: 1500})
 	if err := s.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestCNIServerDirectory(t *testing.T) {
 	if err := ioutil.WriteFile(tmpFile, []byte("foo"), 0444); err != nil {
 		t.Fatalf("could not write tmp file: %v", err)
 	}
-	s = NewCNIServer(runDir, &Config{MTU: 1500})
+	s = NewCNIServer(runDir, &Config{OverlayMTU: 1500})
 	if err := s.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestCNIServerDirectory(t *testing.T) {
 	if err := ioutil.WriteFile(tmpFile, []byte("foo"), 0444); err != nil {
 		t.Fatalf("could not write tmp file: %v", err)
 	}
-	s = NewCNIServer(runDir, &Config{MTU: 1500})
+	s = NewCNIServer(runDir, &Config{OverlayMTU: 1500})
 	if err := s.Start(serverHandleCNI); err != nil {
 		t.Fatalf("error starting CNI server: %v", err)
 	}

--- a/pkg/network/common/common.go
+++ b/pkg/network/common/common.go
@@ -37,7 +37,7 @@ type ParsedClusterNetwork struct {
 	ClusterNetworks []ParsedClusterNetworkEntry
 	ServiceNetwork  *net.IPNet
 	VXLANPort       uint32
-	MTU             uint32
+	OverlayMTU      uint32
 }
 
 type ParsedClusterNetworkEntry struct {
@@ -80,9 +80,9 @@ func ParseClusterNetwork(cn *osdnv1.ClusterNetwork) (*ParsedClusterNetwork, erro
 	}
 
 	if cn.MTU != nil {
-		pcn.MTU = *cn.MTU
+		pcn.OverlayMTU = *cn.MTU
 	} else {
-		pcn.MTU = 1450
+		pcn.OverlayMTU = 1450
 	}
 
 	return pcn, nil

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -14,15 +13,12 @@ import (
 
 	metrics "github.com/openshift/sdn/pkg/network/node/metrics"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
 	kubeletapi "k8s.io/cri-api/pkg/apis"
 	kruntimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
@@ -30,7 +26,6 @@ import (
 	ktypes "k8s.io/kubernetes/pkg/kubelet/types"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/util/iptables"
-	taints "k8s.io/kubernetes/pkg/util/taints"
 	kexec "k8s.io/utils/exec"
 
 	osdnv1 "github.com/openshift/api/network/v1"
@@ -265,10 +260,12 @@ func (node *OsdnNode) validateMTU() error {
 	// TODO(cdc) handle v6-only nodes
 	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
 	if err != nil {
-		return fmt.Errorf("could not list routes while validating MTU: %v", err)
+		klog.Errorf("Could not list routes while validating MTU: %v. (Assuming MTU is valid.)", err)
+		return nil
 	}
 	if len(routes) == 0 {
-		return fmt.Errorf("got no routes while validating MTU")
+		klog.Errorf("Got no routes while validating MTU. (Assuming MTU is valid.)")
+		return nil
 	}
 
 	const maxMTU = 65536
@@ -280,7 +277,8 @@ func (node *OsdnNode) validateMTU() error {
 		}
 		link, err := netlink.LinkByIndex(route.LinkIndex)
 		if err != nil {
-			return fmt.Errorf("could not retrieve link id %d while validating MTU", route.LinkIndex)
+			klog.Errorf("Could not retrieve link id %d while validating MTU. (Assuming MTU is valid.)", route.LinkIndex)
+			return nil
 		}
 
 		// we want to check the MTU only for the interface assigned to the node's primary ip
@@ -302,65 +300,13 @@ func (node *OsdnNode) validateMTU() error {
 		}
 	}
 	if interfaceMTU > maxMTU {
-		return fmt.Errorf("unable to determine MTU while performing validation")
+		klog.Errorf("Unable to determine MTU while performing validation. (Assuming MTU is valid.)")
+		return nil
 	}
 
-	needsTaint := interfaceMTU < int(node.overlayMTU)+50
-	const MTUTaintKey string = "network.openshift.io/mtu-too-small"
-	mtuTooSmallTaint := &corev1.Taint{Key: MTUTaintKey, Value: "value", Effect: "NoSchedule"}
-	nodeObj, err := node.kClient.CoreV1().Nodes().Get(context.TODO(), node.hostName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("could not get Kubernetes Node object by hostname: %v", err)
+	if interfaceMTU < int(node.overlayMTU)+50 {
+		return fmt.Errorf("interface MTU (%d) is too small for specified overlay MTU (%d)", interfaceMTU, node.overlayMTU)
 	}
-	tainted := taints.TaintExists(nodeObj.Spec.Taints, mtuTooSmallTaint)
-	if needsTaint != tainted {
-		resultErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			nodeObj, err = node.kClient.CoreV1().Nodes().Get(context.TODO(), node.hostName, metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("could not get Kubernetes Node object by hostname: %v", err)
-			}
-			nodeObjCopy := nodeObj.DeepCopy()
-			var nodeWithTaintMods *corev1.Node
-
-			if needsTaint && !tainted {
-				klog.V(2).Infof("Default interface MTU is less than VXLAN overhead, tainting node...")
-				nodeWithTaintMods, _, err = taints.AddOrUpdateTaint(nodeObjCopy, mtuTooSmallTaint)
-				if err != nil {
-					return fmt.Errorf("could not taint the node with key %s: %v", MTUTaintKey, err)
-				}
-			} else if !needsTaint && tainted {
-				klog.V(2).Infof("Node has too small MTU taint but default interface MTU is big enough, untainting node...")
-				nodeWithTaintMods, _, err = taints.RemoveTaint(nodeObjCopy, mtuTooSmallTaint)
-				if err != nil {
-					return fmt.Errorf("could not untaint the node with key %s: %v", MTUTaintKey, err)
-				}
-			}
-
-			nodeObjJson, err := json.Marshal(nodeObj)
-			if err != nil {
-				return fmt.Errorf("could not marshal old Node object: %v", err)
-			}
-
-			newNodeObjJson, err := json.Marshal(nodeWithTaintMods)
-			if err != nil {
-				return fmt.Errorf("could not marshal new Node object: %v", err)
-			}
-
-			patchBytes, err := strategicpatch.CreateTwoWayMergePatch(nodeObjJson, newNodeObjJson, corev1.Node{})
-			if err != nil {
-				return fmt.Errorf("could not create patch for object: %v", err)
-			}
-
-			_, err = node.kClient.CoreV1().Nodes().Patch(context.TODO(), node.hostName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
-
-			return err
-		})
-
-		if resultErr != nil {
-			return fmt.Errorf("could not update node taints after many retries: %v", resultErr)
-		}
-	}
-
 	return nil
 }
 
@@ -432,7 +378,7 @@ func (node *OsdnNode) Start() error {
 	}
 
 	if err := node.validateMTU(); err != nil {
-		klog.Errorf("Error validating node MTU: %v", err)
+		return err
 	}
 
 	go kwait.Forever(node.policy.SyncVNIDRules, time.Hour)

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -219,7 +219,7 @@ func (oc *ovsController) AlreadySetUp(vxlanPort uint32) bool {
 	return false
 }
 
-func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway string, mtu uint32, vxlanPort uint32) error {
+func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway string, overlayMTU uint32, vxlanPort uint32) error {
 	err := oc.ovs.DeleteBridge()
 	if err != nil {
 		return err
@@ -238,7 +238,7 @@ func (oc *ovsController) SetupOVS(clusterNetworkCIDR []string, serviceNetworkCID
 		return err
 	}
 	_ = oc.ovs.DeletePort(Tun0)
-	_, err = oc.ovs.AddPort(Tun0, 2, "type=internal", fmt.Sprintf("mtu_request=%d", mtu))
+	_, err = oc.ovs.AddPort(Tun0, 2, "type=internal", fmt.Sprintf("mtu_request=%d", overlayMTU))
 	if err != nil {
 		return err
 	}

--- a/pkg/network/node/pod.go
+++ b/pkg/network/node/pod.go
@@ -61,7 +61,7 @@ type podManager struct {
 	// Live pod setup/teardown stuff not used in testing code
 	kClient     kubernetes.Interface
 	policy      osdnPolicy
-	mtu         uint32
+	overlayMTU  uint32
 	routableMTU uint32
 	ovs         *ovsController
 
@@ -71,11 +71,11 @@ type podManager struct {
 }
 
 // Creates a new live podManager; used by node code0
-func newPodManager(kClient kubernetes.Interface, policy osdnPolicy, mtu uint32, routableMTU uint32, ovs *ovsController) *podManager {
+func newPodManager(kClient kubernetes.Interface, policy osdnPolicy, overlayMTU uint32, routableMTU uint32, ovs *ovsController) *podManager {
 	pm := newDefaultPodManager()
 	pm.kClient = kClient
 	pm.policy = policy
-	pm.mtu = mtu
+	pm.overlayMTU = overlayMTU
 	pm.routableMTU = routableMTU
 	pm.podHandler = pm
 	pm.ovs = ovs
@@ -166,7 +166,7 @@ func (m *podManager) Start(rundir string, localSubnetCIDR string, clusterNetwork
 
 	go m.processCNIRequests()
 
-	m.cniServer = cniserver.NewCNIServer(rundir, &cniserver.Config{MTU: m.mtu, RoutableMTU: m.routableMTU, PlatformType: platformType})
+	m.cniServer = cniserver.NewCNIServer(rundir, &cniserver.Config{OverlayMTU: m.overlayMTU, RoutableMTU: m.routableMTU, PlatformType: platformType})
 	return m.cniServer.Start(m.handleCNIRequest)
 }
 

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -158,7 +158,7 @@ func (plugin *OsdnNode) FinishSetupSDN() error {
 func (plugin *OsdnNode) setup(localSubnetCIDR, localSubnetGateway string) error {
 	serviceNetworkCIDR := plugin.networkInfo.ServiceNetwork.String()
 
-	if err := plugin.oc.SetupOVS(plugin.clusterCIDRs, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway, plugin.mtu, plugin.networkInfo.VXLANPort); err != nil {
+	if err := plugin.oc.SetupOVS(plugin.clusterCIDRs, serviceNetworkCIDR, localSubnetCIDR, localSubnetGateway, plugin.overlayMTU, plugin.networkInfo.VXLANPort); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The "MTU is too small" case never happens in normal operation, and giving openshift-sdn-node write access to all Nodes just for that is excessive. So get rid of the tainting, and if we find the MTU is too small then just (a) emit an Event, and (b) exit with an error (which will prevent the node from becoming Ready anyway).