### PR TITLE
Bug 2062558: egressip: Continue to process other nodes if a node is not ready

### DIFF
--- a/pkg/network/master/egressip.go
+++ b/pkg/network/master/egressip.go
@@ -255,11 +255,11 @@ func (eim *egressIPManager) check(retrying bool) (bool, error) {
 		}
 
 		if !nodeIsReady(nn) {
-			klog.Warningf("Node %s is not Ready", node.name)
+			klog.Warningf("Node %s is not Ready, marking it offline...", node.name)
 			node.offline = true
 			eim.tracker.SetNodeOffline(node.ip, true)
-			// Return when there's a not Ready node
-			return false, nil
+			// continue to process other nodes in the list when we encounter a not Ready node
+			continue
 		}
 
 		online := eim.tracker.Ping(node.sdnIP, timeout)


### PR DESCRIPTION
If a node is not ready, continue to process other nodes in the
list after marking it offline instead of returning immediately
since if there are other nodes that are offline at the same
time we need to make sure we mark those nodes as offline as
well to be able to do re-assignment of egressIPs.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>

/cc @danwinship @kyrtapz @flavio-fernandes 