### PR TITLE
Bug 2016534: Masquerade in cluster traffic that is marked for egress IP

### DIFF
--- a/pkg/network/node/iptables.go
+++ b/pkg/network/node/iptables.go
@@ -297,11 +297,16 @@ func (n *NodeIPTables) getNodeIPTablesChains() []Chain {
 
 func (n *NodeIPTables) ensureEgressIPRules(egressIP, mark string) error {
 	for _, cidr := range n.clusterNetworkCIDR {
-		err := execIPTablesWithRetry(func() error {
+		if err := execIPTablesWithRetry(func() error {
 			_, err := n.ipt.EnsureRule(iptables.Prepend, iptables.TableNAT, iptables.Chain("OPENSHIFT-MASQUERADE"), "-s", cidr, "-m", "mark", "--mark", mark, "-j", "SNAT", "--to-source", egressIP)
+			if err != nil {
+				return err
+			}
+			// EgressIP cannot be used for destination IPs that are in cluster network.
+			// In a scenario where the destination got DNATed to an IP in cluster network(ExternalIP, LoadBalancer) masquerade the traffic so both DNAT and unDNAT happen on the same node.
+			_, err = n.ipt.EnsureRule(iptables.Prepend, iptables.TableNAT, iptables.Chain("OPENSHIFT-MASQUERADE"), "-s", cidr, "-d", cidr, "-m", "mark", "--mark", mark, "-j", "MASQUERADE")
 			return err
-		})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}
@@ -330,10 +335,13 @@ func (n *NodeIPTables) DeleteEgressIPRules(egressIP, mark string) error {
 	delete(n.egressIPs, egressIP)
 
 	for _, cidr := range n.clusterNetworkCIDR {
-		err := execIPTablesWithRetry(func() error {
+		if err := execIPTablesWithRetry(func() error {
+			err := n.ipt.DeleteRule(iptables.TableNAT, iptables.Chain("OPENSHIFT-MASQUERADE"), "-s", cidr, "-d", cidr, "-m", "mark", "--mark", mark, "-j", "MASQUERADE")
+			if err != nil {
+				return err
+			}
 			return n.ipt.DeleteRule(iptables.TableNAT, iptables.Chain("OPENSHIFT-MASQUERADE"), "-s", cidr, "-m", "mark", "--mark", mark, "-j", "SNAT", "--to-source", egressIP)
-		})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
/cc

In a scenario where an ExternalIP/LoadBalancer is used by a pod with an egress IP configured the packets will be marked and redirected to the egress node using ovs flows.
On the egress node, the traffic will be DNATed to an IP that is in the cluster network. Instead of SNATing to an egress IP masquerade the outgoing packets to ensure that the response traffic is sent back through the same node.

Signed-off-by: Patryk Diak <pdiak@redhat.com>