### PR TITLE
Bug 2016534: Exclude the default drop bit from egress IP VNID

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	defaultPollInterval = 5 * time.Second
-	repollInterval      = time.Second
-	maxRetries          = 2
+	defaultPollInterval   = 5 * time.Second
+	repollInterval        = time.Second
+	maxRetries            = 2
+	defaultKubeletDropBit = 1 << uint32(15) // https://github.com/kubernetes/kubelet/blob/release-1.24/config/v1beta1/types.go#L555
 )
 
 type egressNode struct {
@@ -125,11 +126,14 @@ func egressIPLabel(link netlink.Link) (string, error) {
 	return label, nil
 }
 
-// Convert vnid to a hex value that is not 0, does not have masqueradeBit set, and isn't
+// Convert vnid to a hex value that is not 0, does not have masqueradeBit and defaultKubeletDropBit set, and isn't
 // the same value as would be returned for any other valid vnid.
 func getMarkForVNID(vnid, masqueradeBit uint32) string {
 	if vnid == 0 {
 		vnid = 0xff000000
+	}
+	if (vnid & defaultKubeletDropBit) != 0 {
+		vnid = (vnid | 0x10000000) ^ defaultKubeletDropBit
 	}
 	if (vnid & masqueradeBit) != 0 {
 		vnid = (vnid | 0x01000000) ^ masqueradeBit

--- a/pkg/network/node/egressip_test.go
+++ b/pkg/network/node/egressip_test.go
@@ -992,6 +992,24 @@ func TestMarkForVNID(t *testing.T) {
 			masqueradeBit: 0x00000000,
 			result:        0xff000000,
 		},
+		{
+			description:   "masqBit == bit 25, VNID == defaultKubeletDropBit",
+			vnid:          defaultKubeletDropBit,
+			masqueradeBit: 0x10000000,
+			result:        0x01000000,
+		},
+		{
+			description:   "no masqBit, VNID matches defaultKubeletDropBit",
+			vnid:          0x00008aaa,
+			masqueradeBit: 0x00000000,
+			result:        0x10000aaa,
+		},
+		{
+			description:   "masqBit == 1, VNID == defaultKubeletDropBit | 1",
+			vnid:          defaultKubeletDropBit | 1,
+			masqueradeBit: 1,
+			result:        0x11000000,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
This is needed for egress IP traffic that is DNATed to a local IP(ExternalIP/LoadBalancer).
This type of traffic traverses KUBE-FIREWALL chain which drops packets marked with the default drop bit.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2082451#c3
Signed-off-by: Patryk Diak <pdiak@redhat.com>