### PR TITLE
OCPBUGS-2105: fix network policy egress

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -746,13 +746,9 @@ func (np *networkPolicyPlugin) parsePeerFlows(npns *npNamespace, npp *npPolicy, 
 	peerFlows := []string{}
 	for _, peer := range peers {
 		if peer.PodSelector != nil && peer.NamespaceSelector == nil {
-			if len(peer.PodSelector.MatchLabels) == 0 && len(peer.PodSelector.MatchExpressions) == 0 {
+			if dir == ingressFlow && (len(peer.PodSelector.MatchLabels) == 0 && len(peer.PodSelector.MatchExpressions) == 0) {
 				// The PodSelector is empty, meaning it selects all pods in this namespace
-				if dir == ingressFlow {
-					peerFlows = append(peerFlows, fmt.Sprintf("reg0=%d, ", npns.vnid))
-				} else {
-					peerFlows = append(peerFlows, fmt.Sprintf("reg1=%d, ", npns.vnid))
-				}
+				peerFlows = append(peerFlows, fmt.Sprintf("reg0=%d, ", npns.vnid))
 			} else {
 				npp.watchesOwnPods = true
 				for _, ip := range np.selectPods(npns, peer.PodSelector) {


### PR DESCRIPTION
in the case where an egress rule has no namespaceSelector and an empty pod Selector we generate a flow fmt.Sprintf("reg1=%d, ", npns.vnid), that is wrong because reg1 is not set at this point.

the egress flows need to be generated using only podIPs rather then VNIDs for egress flows

clean backport of the master commit