### PR TITLE
Bug 2050230: pass ResourceVersion:0 for kube List() calls

### DIFF
--- a/pkg/network/common/kube_list.go
+++ b/pkg/network/common/kube_list.go
@@ -18,9 +18,12 @@ import (
 
 func ListAllEgressNetworkPolicies(ctx context.Context, client osdnclient.Interface) ([]*osdnv1.EgressNetworkPolicy, error) {
 	list := []*osdnv1.EgressNetworkPolicy{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.NetworkV1().EgressNetworkPolicies(metav1.NamespaceAll).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*osdnv1.EgressNetworkPolicy))
 		return nil
 	})
@@ -29,9 +32,12 @@ func ListAllEgressNetworkPolicies(ctx context.Context, client osdnclient.Interfa
 
 func ListAllNamespaces(ctx context.Context, client kubernetes.Interface) ([]*corev1.Namespace, error) {
 	list := []*corev1.Namespace{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.CoreV1().Namespaces().List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*corev1.Namespace))
 		return nil
 	})
@@ -40,9 +46,12 @@ func ListAllNamespaces(ctx context.Context, client kubernetes.Interface) ([]*cor
 
 func ListAllNetworkPolicies(ctx context.Context, client kubernetes.Interface) ([]*networkingv1.NetworkPolicy, error) {
 	list := []*networkingv1.NetworkPolicy{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.NetworkingV1().NetworkPolicies(metav1.NamespaceAll).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*networkingv1.NetworkPolicy))
 		return nil
 	})
@@ -51,9 +60,12 @@ func ListAllNetworkPolicies(ctx context.Context, client kubernetes.Interface) ([
 
 func ListAllPods(ctx context.Context, client kubernetes.Interface) ([]*corev1.Pod, error) {
 	list := []*corev1.Pod{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*corev1.Pod))
 		return nil
 	})
@@ -62,9 +74,12 @@ func ListAllPods(ctx context.Context, client kubernetes.Interface) ([]*corev1.Po
 
 func ListAllServices(ctx context.Context, client kubernetes.Interface) ([]*corev1.Service, error) {
 	list := []*corev1.Service{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.CoreV1().Services(metav1.NamespaceAll).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*corev1.Service))
 		return nil
 	})
@@ -73,9 +88,12 @@ func ListAllServices(ctx context.Context, client kubernetes.Interface) ([]*corev
 
 func ListServicesInNamespace(ctx context.Context, client kubernetes.Interface, namespace string) ([]*corev1.Service, error) {
 	list := []*corev1.Service{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.CoreV1().Services(namespace).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*corev1.Service))
 		return nil
 	})
@@ -84,9 +102,12 @@ func ListServicesInNamespace(ctx context.Context, client kubernetes.Interface, n
 
 func ListAllHostSubnets(ctx context.Context, client osdnclient.Interface) ([]*osdnv1.HostSubnet, error) {
 	list := []*osdnv1.HostSubnet{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.NetworkV1().HostSubnets().List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*osdnv1.HostSubnet))
 		return nil
 	})
@@ -95,9 +116,12 @@ func ListAllHostSubnets(ctx context.Context, client osdnclient.Interface) ([]*os
 
 func ListAllNetNamespaces(ctx context.Context, client osdnclient.Interface) ([]*osdnv1.NetNamespace, error) {
 	list := []*osdnv1.NetNamespace{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.NetworkV1().NetNamespaces().List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*osdnv1.NetNamespace))
 		return nil
 	})
@@ -107,8 +131,9 @@ func ListAllNetNamespaces(ctx context.Context, client osdnclient.Interface) ([]*
 func ListPodsInNodeAndNamespace(ctx context.Context, client kubernetes.Interface, node, namespace string) ([]*corev1.Pod, error) {
 	fieldSelector := fields.Set{"spec.nodeName": node}.AsSelector()
 	opts := metav1.ListOptions{
-		LabelSelector: labels.Everything().String(),
-		FieldSelector: fieldSelector.String(),
+		LabelSelector:   labels.Everything().String(),
+		FieldSelector:   fieldSelector.String(),
+		ResourceVersion: "0",
 	}
 	list := []*corev1.Pod{}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {


### PR DESCRIPTION
Set ResourceVersion to 0 so that list requests are served from the api server cache instead of etcd.

Keep pagination, as requests may still fallback to etcd if the apiserver cache has not been initialized yet (i.e. apiserver restart).

Ref: https://github.com/kubernetes/enhancements/blob/328e235effab8ba0869586bdb4ee7b10a0ee0801/keps/sig-api-machinery/3157-watch-list/README.md#appendix

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>