### PR TITLE
OCPBUGS-95: Retry IP re-assignment on failure

### DIFF
--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -174,11 +174,27 @@ func (eip *egressIPWatcher) runIPAssignmentResync(stopCh <-chan struct{}) {
 		return err
 	}
 
+	// ~1 sec total
+	syncIPsBackOff := utilwait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   1.25,
+		Steps:    7,
+	}
 	syncIPs := func() {
 		eip.tracker.Lock()
 		defer eip.tracker.Unlock()
 
-		eip.SyncIPAssignments()
+		var lastSyncErr error
+		if err := utilwait.ExponentialBackoff(syncIPsBackOff, func() (bool, error) {
+			if err := eip.SyncIPAssignments(); err != nil {
+				klog.V(5).Infof("Error synchronizing IP assignments: %v", err)
+				lastSyncErr = err
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
+			klog.Errorf("Failed to sync IP assignments: %v", lastSyncErr)
+		}
 	}
 
 	subscribeErr := addrSubscribe()


### PR DESCRIPTION
This a follow up to https://github.com/openshift/sdn/pull/463

When an egress IP address is removed from an interface re-assignment can fail due to link related issues:
```
I1208 11:14:31.723113  416310 egressip.go:222] Egress IP 10.73.116.150 removed from the interface, syncing assignments
I1208 11:14:31.811133  416310 egressip.go:190] Error synchronizing IP assignments: could not get 10.73.116.58 link details could not find network interface
I1208 11:14:31.913292  416310 egressip.go:121] Assigning missing egress IP 10.73.116.150
```
This was discovered using nmstate on a  bare-metal cluster.

Introduced a retry to address intermittent failures.

Signed-off-by: Patryk Diak <pdiak@redhat.com>