### PR TITLE
OCPBUGS-7227: Update for 4.12 / go 1.19, including gofmt updates

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/images/kube-proxy/Dockerfile.rhel
+++ b/images/kube-proxy/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/sdn
 COPY . .
 RUN make build --warn-undefined-variables

--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/sdn
 COPY . .
 RUN make build --warn-undefined-variables
 RUN CGO_ENABLED=0 GO_BUILD_FLAGS="-tags no_openssl" make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/openshift-sdn-cni" --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.11:base
+FROM registry.ci.openshift.org/ocp/4.12:base
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn-node /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn-controller /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/openshift-sdn

--- a/pkg/network/node/egressip_test.go
+++ b/pkg/network/node/egressip_test.go
@@ -128,7 +128,7 @@ func assertNoOVSChanges(eip *egressIPWatcher, flows *[]string) error {
 	return assertOVSChanges(eip, flows)
 }
 
-//determine if the the groups are the same regardless of order
+// determine if the the groups are the same regardless of order
 func compareGroups(groups []string, expectedGroups []string) (bool, error) {
 	//both groups and expected should be the same size
 	if len(groups) != len(expectedGroups) {

--- a/pkg/util/ranges/networkpolicy.go
+++ b/pkg/util/ranges/networkpolicy.go
@@ -15,11 +15,11 @@ import (
 // the effect of "&&", but there's no way to say "!="... The only way to make this work is
 // to rewrite
 //
-//    nw_src=[A-H] && nw_src!=B && nw_src!=E
+//	nw_src=[A-H] && nw_src!=B && nw_src!=E
 //
 // as
 //
-//    nw_src=A || nw_src=[C-D] || nw_src=[F-H]
+//	nw_src=A || nw_src=[C-D] || nw_src=[F-H]
 //
 // except that it's more complicated than that because CIDRs can only express ranges
 // whose lengths are powers of 2. So, we call rangesForIPBlock() to generate the list


### PR DESCRIPTION
autogenerated ART PRs (#446, #460) had failed because of required gofmt changes