### PR TITLE
do not strip binary files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GO111MODULE=on
 unexport GOPATH
 
 GO_LD_FLAGS = \
-    -ldflags "-w $(call version-ldflags,$(GO_PACKAGE)/pkg/version) $(GO_LD_EXTRAFLAGS)"
+    -ldflags "$(call version-ldflags,$(GO_PACKAGE)/pkg/version) $(GO_LD_EXTRAFLAGS)"
 
 GO_BUILD_PACKAGES = \
     ./cmd/... \


### PR DESCRIPTION
by removing the "-w" flag in the make file we leave in the DWARF symbol table during compilation leaves in the debug information. This will allow us to get data from coredumps

discussion from the last time that we removed flags that stripped the symbol tables  https://github.com/openshift/sdn/pull/221 