### PR TITLE
[release-4.10] OCPBUGS-5977: Use pagination and set ResourceVersion to 0 when listing resources

### DIFF
--- a/pkg/network/common/common.go
+++ b/pkg/network/common/common.go
@@ -145,7 +145,7 @@ func (pcn *ParsedClusterNetwork) CheckHostNetworks(hostIPNets []*net.IPNet) erro
 	return kerrors.NewAggregate(errList)
 }
 
-func (pcn *ParsedClusterNetwork) CheckClusterObjects(subnets []osdnv1.HostSubnet, pods []corev1.Pod, services []corev1.Service) error {
+func (pcn *ParsedClusterNetwork) CheckClusterObjects(subnets []*osdnv1.HostSubnet, pods []*corev1.Pod, services []*corev1.Service) error {
 	var errList []error
 
 	for _, subnet := range subnets {

--- a/pkg/network/common/common_test.go
+++ b/pkg/network/common/common_test.go
@@ -118,25 +118,25 @@ func TestCheckHostNetworks(t *testing.T) {
 	}
 }
 
-func dummySubnet(hostip string, subnet string) osdnv1.HostSubnet {
-	return osdnv1.HostSubnet{HostIP: hostip, Subnet: subnet}
+func dummySubnet(hostip string, subnet string) *osdnv1.HostSubnet {
+	return &osdnv1.HostSubnet{HostIP: hostip, Subnet: subnet}
 }
 
-func dummyService(ip string) corev1.Service {
-	return corev1.Service{Spec: corev1.ServiceSpec{ClusterIP: ip}}
+func dummyService(ip string) *corev1.Service {
+	return &corev1.Service{Spec: corev1.ServiceSpec{ClusterIP: ip}}
 }
 
-func dummyPod(ip string) corev1.Pod {
-	return corev1.Pod{Status: corev1.PodStatus{PodIP: ip}}
+func dummyPod(ip string) *corev1.Pod {
+	return &corev1.Pod{Status: corev1.PodStatus{PodIP: ip}}
 }
 
 func Test_checkClusterObjects(t *testing.T) {
-	subnets := []osdnv1.HostSubnet{
+	subnets := []*osdnv1.HostSubnet{
 		dummySubnet("192.168.1.2", "10.128.0.0/23"),
 		dummySubnet("192.168.1.3", "10.129.0.0/23"),
 		dummySubnet("192.168.1.4", "10.130.0.0/23"),
 	}
-	pods := []corev1.Pod{
+	pods := []*corev1.Pod{
 		dummyPod("10.128.0.2"),
 		dummyPod("10.128.0.4"),
 		dummyPod("10.128.0.6"),
@@ -147,7 +147,7 @@ func Test_checkClusterObjects(t *testing.T) {
 		dummyPod("10.129.0.9"),
 		dummyPod("10.130.0.10"),
 	}
-	services := []corev1.Service{
+	services := []*corev1.Service{
 		dummyService("172.30.0.1"),
 		dummyService("172.30.0.128"),
 		dummyService("172.30.99.99"),

--- a/pkg/network/common/kube_list.go
+++ b/pkg/network/common/kube_list.go
@@ -18,9 +18,12 @@ import (
 
 func ListAllEgressNetworkPolicies(ctx context.Context, client osdnclient.Interface) ([]*osdnv1.EgressNetworkPolicy, error) {
 	list := []*osdnv1.EgressNetworkPolicy{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.NetworkV1().EgressNetworkPolicies(metav1.NamespaceAll).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*osdnv1.EgressNetworkPolicy))
 		return nil
 	})
@@ -29,9 +32,12 @@ func ListAllEgressNetworkPolicies(ctx context.Context, client osdnclient.Interfa
 
 func ListAllNamespaces(ctx context.Context, client kubernetes.Interface) ([]*corev1.Namespace, error) {
 	list := []*corev1.Namespace{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.CoreV1().Namespaces().List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*corev1.Namespace))
 		return nil
 	})
@@ -40,9 +46,12 @@ func ListAllNamespaces(ctx context.Context, client kubernetes.Interface) ([]*cor
 
 func ListAllNetworkPolicies(ctx context.Context, client kubernetes.Interface) ([]*networkingv1.NetworkPolicy, error) {
 	list := []*networkingv1.NetworkPolicy{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.NetworkingV1().NetworkPolicies(metav1.NamespaceAll).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*networkingv1.NetworkPolicy))
 		return nil
 	})
@@ -51,9 +60,12 @@ func ListAllNetworkPolicies(ctx context.Context, client kubernetes.Interface) ([
 
 func ListAllPods(ctx context.Context, client kubernetes.Interface) ([]*corev1.Pod, error) {
 	list := []*corev1.Pod{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*corev1.Pod))
 		return nil
 	})
@@ -62,9 +74,12 @@ func ListAllPods(ctx context.Context, client kubernetes.Interface) ([]*corev1.Po
 
 func ListAllServices(ctx context.Context, client kubernetes.Interface) ([]*corev1.Service, error) {
 	list := []*corev1.Service{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.CoreV1().Services(metav1.NamespaceAll).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*corev1.Service))
 		return nil
 	})
@@ -73,9 +88,12 @@ func ListAllServices(ctx context.Context, client kubernetes.Interface) ([]*corev
 
 func ListServicesInNamespace(ctx context.Context, client kubernetes.Interface, namespace string) ([]*corev1.Service, error) {
 	list := []*corev1.Service{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.CoreV1().Services(namespace).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*corev1.Service))
 		return nil
 	})
@@ -84,9 +102,12 @@ func ListServicesInNamespace(ctx context.Context, client kubernetes.Interface, n
 
 func ListAllHostSubnets(ctx context.Context, client osdnclient.Interface) ([]*osdnv1.HostSubnet, error) {
 	list := []*osdnv1.HostSubnet{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.NetworkV1().HostSubnets().List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*osdnv1.HostSubnet))
 		return nil
 	})
@@ -95,9 +116,12 @@ func ListAllHostSubnets(ctx context.Context, client osdnclient.Interface) ([]*os
 
 func ListAllNetNamespaces(ctx context.Context, client osdnclient.Interface) ([]*osdnv1.NetNamespace, error) {
 	list := []*osdnv1.NetNamespace{}
+	opts := metav1.ListOptions{
+		ResourceVersion: "0",
+	}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		return client.NetworkV1().NetNamespaces().List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
 		list = append(list, obj.(*osdnv1.NetNamespace))
 		return nil
 	})
@@ -107,8 +131,9 @@ func ListAllNetNamespaces(ctx context.Context, client osdnclient.Interface) ([]*
 func ListPodsInNodeAndNamespace(ctx context.Context, client kubernetes.Interface, node, namespace string) ([]*corev1.Pod, error) {
 	fieldSelector := fields.Set{"spec.nodeName": node}.AsSelector()
 	opts := metav1.ListOptions{
-		LabelSelector: labels.Everything().String(),
-		FieldSelector: fieldSelector.String(),
+		LabelSelector:   labels.Everything().String(),
+		FieldSelector:   fieldSelector.String(),
+		ResourceVersion: "0",
 	}
 	list := []*corev1.Pod{}
 	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {

--- a/pkg/network/common/list_pager.go
+++ b/pkg/network/common/list_pager.go
@@ -1,0 +1,121 @@
+package common
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/pager"
+
+	osdnv1 "github.com/openshift/api/network/v1"
+	osdnclient "github.com/openshift/client-go/network/clientset/versioned"
+)
+
+func ListAllEgressNetworkPolicies(ctx context.Context, client osdnclient.Interface) ([]*osdnv1.EgressNetworkPolicy, error) {
+	list := []*osdnv1.EgressNetworkPolicy{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.NetworkV1().EgressNetworkPolicies(metav1.NamespaceAll).List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*osdnv1.EgressNetworkPolicy))
+		return nil
+	})
+	return list, err
+}
+
+func ListAllNamespaces(ctx context.Context, client kubernetes.Interface) ([]*corev1.Namespace, error) {
+	list := []*corev1.Namespace{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.CoreV1().Namespaces().List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*corev1.Namespace))
+		return nil
+	})
+	return list, err
+}
+
+func ListAllNetworkPolicies(ctx context.Context, client kubernetes.Interface) ([]*networkingv1.NetworkPolicy, error) {
+	list := []*networkingv1.NetworkPolicy{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.NetworkingV1().NetworkPolicies(metav1.NamespaceAll).List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*networkingv1.NetworkPolicy))
+		return nil
+	})
+	return list, err
+}
+
+func ListAllPods(ctx context.Context, client kubernetes.Interface) ([]*corev1.Pod, error) {
+	list := []*corev1.Pod{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*corev1.Pod))
+		return nil
+	})
+	return list, err
+}
+
+func ListAllServices(ctx context.Context, client kubernetes.Interface) ([]*corev1.Service, error) {
+	list := []*corev1.Service{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.CoreV1().Services(metav1.NamespaceAll).List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*corev1.Service))
+		return nil
+	})
+	return list, err
+}
+
+func ListServicesInNamespace(ctx context.Context, client kubernetes.Interface, namespace string) ([]*corev1.Service, error) {
+	list := []*corev1.Service{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.CoreV1().Services(namespace).List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*corev1.Service))
+		return nil
+	})
+	return list, err
+}
+
+func ListAllHostSubnets(ctx context.Context, client osdnclient.Interface) ([]*osdnv1.HostSubnet, error) {
+	list := []*osdnv1.HostSubnet{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.NetworkV1().HostSubnets().List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*osdnv1.HostSubnet))
+		return nil
+	})
+	return list, err
+}
+
+func ListAllNetNamespaces(ctx context.Context, client osdnclient.Interface) ([]*osdnv1.NetNamespace, error) {
+	list := []*osdnv1.NetNamespace{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.NetworkV1().NetNamespaces().List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		list = append(list, obj.(*osdnv1.NetNamespace))
+		return nil
+	})
+	return list, err
+}
+
+func ListPodsInNodeAndNamespace(ctx context.Context, client kubernetes.Interface, node, namespace string) ([]*corev1.Pod, error) {
+	fieldSelector := fields.Set{"spec.nodeName": node}.AsSelector()
+	opts := metav1.ListOptions{
+		LabelSelector: labels.Everything().String(),
+		FieldSelector: fieldSelector.String(),
+	}
+	list := []*corev1.Pod{}
+	err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.CoreV1().Pods(namespace).List(ctx, opts)
+	}).EachListItem(ctx, opts, func(obj runtime.Object) error {
+		list = append(list, obj.(*corev1.Pod))
+		return nil
+	})
+	return list, err
+}

--- a/pkg/network/master/subnets.go
+++ b/pkg/network/master/subnets.go
@@ -28,11 +28,11 @@ func (master *OsdnMaster) startSubnetMaster() error {
 	}
 
 	// Populate subnet allocator
-	subnets, err := master.osdnClient.NetworkV1().HostSubnets().List(context.TODO(), metav1.ListOptions{})
+	subnets, err := common.ListAllHostSubnets(context.TODO(), master.osdnClient)
 	if err != nil {
 		return err
 	}
-	for _, sn := range subnets.Items {
+	for _, sn := range subnets {
 		if err := master.subnetAllocator.MarkAllocatedNetwork(sn.Subnet); err != nil {
 			klog.Errorf("Error marking allocated subnet: %v", err)
 		}

--- a/pkg/network/master/vnids.go
+++ b/pkg/network/master/vnids.go
@@ -276,12 +276,12 @@ func (master *OsdnMaster) startVNIDMaster() error {
 }
 
 func (master *OsdnMaster) initNetIDAllocator() error {
-	netnsList, err := master.osdnClient.NetworkV1().NetNamespaces().List(context.TODO(), metav1.ListOptions{})
+	netnsList, err := common.ListAllNetNamespaces(context.TODO(), master.osdnClient)
 	if err != nil {
 		return err
 	}
 
-	for _, netns := range netnsList.Items {
+	for _, netns := range netnsList {
 		if err := master.vnids.markAllocatedNetID(netns.NetID); err != nil {
 			klog.Errorf("Error marking allocated VNID: %v", err)
 		}

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -190,11 +190,11 @@ func (np *networkPolicyPlugin) Start(node *OsdnNode) error {
 func (np *networkPolicyPlugin) initNamespaces() error {
 	inUseVNIDs := np.node.oc.FindPolicyVNIDs()
 
-	namespaces, err := np.node.kClient.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	namespaces, err := common.ListAllNamespaces(context.TODO(), np.node.kClient)
 	if err != nil {
 		return err
 	}
-	for _, ns := range namespaces.Items {
+	for _, ns := range namespaces {
 		npns := newNPNamespace(ns.Name)
 		npns.labels = ns.Labels
 		npns.gotNamespace = true
@@ -210,17 +210,17 @@ func (np *networkPolicyPlugin) initNamespaces() error {
 		}
 	}
 
-	policies, err := np.node.kClient.NetworkingV1().NetworkPolicies(corev1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	policies, err := common.ListAllNetworkPolicies(context.TODO(), np.node.kClient)
 	if err != nil {
 		return err
 	}
-	for _, policy := range policies.Items {
+	for _, policy := range policies {
 		vnid, err := np.vnids.getVNID(policy.Namespace)
 		if err != nil {
 			continue
 		}
 		npns := np.namespaces[vnid]
-		np.updateNetworkPolicy(npns, &policy)
+		np.updateNetworkPolicy(npns, policy)
 	}
 
 	return nil

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -14,8 +14,6 @@ import (
 	metrics "github.com/openshift/sdn/pkg/network/node/metrics"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -480,21 +478,16 @@ func (node *OsdnNode) UpdatePod(pod corev1.Pod) error {
 }
 
 func (node *OsdnNode) GetRunningPods(namespace string) ([]corev1.Pod, error) {
-	fieldSelector := fields.Set{"spec.nodeName": node.hostName}.AsSelector()
-	opts := metav1.ListOptions{
-		LabelSelector: labels.Everything().String(),
-		FieldSelector: fieldSelector.String(),
-	}
-	podList, err := node.kClient.CoreV1().Pods(namespace).List(context.TODO(), opts)
+	podList, err := common.ListPodsInNodeAndNamespace(context.TODO(), node.kClient, node.hostName, namespace)
 	if err != nil {
 		return nil, err
 	}
 
 	// Filter running pods
-	pods := make([]corev1.Pod, 0, len(podList.Items))
-	for _, pod := range podList.Items {
+	pods := []corev1.Pod{}
+	for _, pod := range podList {
 		if pod.Status.Phase == corev1.PodRunning {
-			pods = append(pods, pod)
+			pods = append(pods, *pod)
 		}
 	}
 	return pods, nil

--- a/pkg/network/node/vnids.go
+++ b/pkg/network/node/vnids.go
@@ -184,13 +184,13 @@ func netnsIsMulticastEnabled(netns *osdnv1.NetNamespace) bool {
 }
 
 func (vmap *nodeVNIDMap) populateVNIDs() error {
-	nets, err := vmap.osdnClient.NetworkV1().NetNamespaces().List(context.TODO(), metav1.ListOptions{})
+	nets, err := common.ListAllNetNamespaces(context.TODO(), vmap.osdnClient)
 	if err != nil {
 		return err
 	}
 
-	for _, net := range nets.Items {
-		vmap.setVNID(net.Name, net.NetID, netnsIsMulticastEnabled(&net))
+	for _, net := range nets {
+		vmap.setVNID(net.Name, net.NetID, netnsIsMulticastEnabled(net))
 	}
 	return nil
 }


### PR DESCRIPTION
Using the resource List API without pagination overloads etcd
for a high number of resources. Use pagination with the default page
item count, currently 500.

Set ResourceVersion to 0 so that list requests are served from the api
server cache instead of etcd. Requests may fallback to etcd if the apiserver
cache has not been initialized yet (i.e. apiserver restart).

Ref: https://github.com/kubernetes/enhancements/blob/328e235effab8ba0869586bdb4ee7b10a0ee0801/keps/sig-api-machinery/3157-watch-list/README.md#appendix