### PR TITLE
iptables: use container iptables, not host's

### DIFF
--- a/images/iptables-scripts/ip6tables
+++ b/images/iptables-scripts/ip6tables
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/ip6tables "$@"

--- a/images/iptables-scripts/ip6tables-restore
+++ b/images/iptables-scripts/ip6tables-restore
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/ip6tables-restore "$@"

--- a/images/iptables-scripts/ip6tables-save
+++ b/images/iptables-scripts/ip6tables-save
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/ip6tables-save "$@"

--- a/images/iptables-scripts/iptables
+++ b/images/iptables-scripts/iptables
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables "$@"

--- a/images/iptables-scripts/iptables-restore
+++ b/images/iptables-scripts/iptables-restore
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables-restore "$@"

--- a/images/iptables-scripts/iptables-save
+++ b/images/iptables-scripts/iptables-save
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec chroot /host /usr/sbin/iptables-save "$@"

--- a/images/kube-proxy/Dockerfile.rhel
+++ b/images/kube-proxy/Dockerfile.rhel
@@ -4,17 +4,11 @@ COPY . .
 RUN make build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.13:base
-RUN INSTALL_PKGS="conntrack-tools" && \
+RUN INSTALL_PKGS="conntrack-tools iptables" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum clean all && rm -rf /var/cache/*
 
 COPY --from=builder /go/src/github.com/openshift/sdn/kube-proxy /usr/bin/
-COPY ./images/iptables-scripts/iptables /usr/sbin/
-COPY ./images/iptables-scripts/iptables-save /usr/sbin/
-COPY ./images/iptables-scripts/iptables-restore /usr/sbin/
-COPY ./images/iptables-scripts/ip6tables /usr/sbin/
-COPY ./images/iptables-scripts/ip6tables-save /usr/sbin/
-COPY ./images/iptables-scripts/ip6tables-restore /usr/sbin/
 
 LABEL io.k8s.display-name="Kubernetes kube-proxy" \
       io.k8s.description="Provides kube-proxy for external CNI plugins" \

--- a/images/sdn/Dockerfile.fedora
+++ b/images/sdn/Dockerfile.fedora
@@ -22,17 +22,10 @@ RUN INSTALL_PKGS=" \
       libmnl libnetfilter_conntrack conntrack-tools \
       libnfnetlink iproute procps-ng openssl \
       iputils binutils xz util-linux dbus nftables \
-      tcpdump gdb" && \
+      tcpdump gdb iptables" && \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     mkdir -p /etc/sysconfig/cni/net.d && \
     yum clean all && rm -rf /var/cache/*
-
-COPY ./images/iptables-scripts/iptables /usr/sbin/
-COPY ./images/iptables-scripts/iptables-save /usr/sbin/
-COPY ./images/iptables-scripts/iptables-restore /usr/sbin/
-COPY ./images/iptables-scripts/ip6tables /usr/sbin/
-COPY ./images/iptables-scripts/ip6tables-save /usr/sbin/
-COPY ./images/iptables-scripts/ip6tables-restore /usr/sbin/
 
 LABEL io.k8s.display-name="OpenShift SDN" \
       io.k8s.description="This is a component of OpenShift and contains the default SDN implementation." \

--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -15,17 +15,10 @@ RUN INSTALL_PKGS=" \
       libmnl libnetfilter_conntrack conntrack-tools \
       libnfnetlink iproute procps-ng openssl \
       iputils binutils xz util-linux dbus nftables \
-      tcpdump" && \
+      tcpdump iptables" && \
     yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     mkdir -p /etc/sysconfig/cni/net.d && \
     yum clean all && rm -rf /var/cache/*
-
-COPY ./images/iptables-scripts/iptables /usr/sbin/
-COPY ./images/iptables-scripts/iptables-save /usr/sbin/
-COPY ./images/iptables-scripts/iptables-restore /usr/sbin/
-COPY ./images/iptables-scripts/ip6tables /usr/sbin/
-COPY ./images/iptables-scripts/ip6tables-save /usr/sbin/
-COPY ./images/iptables-scripts/ip6tables-restore /usr/sbin/
 
 LABEL io.k8s.display-name="OpenShift SDN" \
       io.k8s.description="This is a component of OpenShift and contains the default SDN implementation." \


### PR DESCRIPTION
Using the host's iptables was necessary when the container image might have been running on RHEL7 BYOH, but given that's no longer possible, we can clean this up and just use the container's iptables (since both it and the host will be iptables-nft).