### PR TITLE
OCPBUGS-6842: Handle race condition to setup default vnid flows

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -56,6 +56,13 @@ type networkPolicyPlugin struct {
 	// since pod.Status.PodIP is not set during pod creation, we keep a separate cache of ips already known to sdn,
 	// but not yet known to the apiserver. When pod.Status.PodIP is set, pod can be deleted from this map
 	localPodIPs map[ktypes.UID]string
+	// unProcessedVNIDs holds the vnid entries for which EnsureVNIDRules() is already invoked upon
+	// pod setup even before AddNetNamespace() is invoked. This is possible when WaitAndGetVNID()
+	// could return the vnid in the pod setup thread and then the setup thread continues, before
+	// the AddNetNamespace() call runs in the handler thread. In such scenario populate the vnid
+	// into unProcessedVNIDs in EnsureVNIDRules() method and it can be looked up later in
+	// AddNetNamespace() method so that required nw policy flow rules programmed into OVS.
+	unProcessedVNIDs sets.Int32
 }
 
 // npNamespace tracks NetworkPolicy-related data for a Namespace
@@ -118,6 +125,8 @@ func NewNetworkPolicyPlugin() osdnPolicy {
 		warnedPolicies:  make(map[ktypes.UID]string),
 		skippedPolicies: make(map[ktypes.UID]string),
 		localPodIPs:     make(map[ktypes.UID]string),
+
+		unProcessedVNIDs: sets.NewInt32(),
 	}
 }
 
@@ -247,6 +256,16 @@ func (np *networkPolicyPlugin) AddNetNamespace(netns *osdnv1.NetNamespace) {
 	npns.inUse = false
 	np.namespaces[netns.NetID] = npns
 
+	var needNsSync bool
+	if np.unProcessedVNIDs.Has(int32(npns.vnid)) {
+		needNsSync = true
+		np.unProcessedVNIDs.Delete(int32(npns.vnid))
+	}
+	if needNsSync {
+		npns.inUse = true
+		np.syncNamespace(npns)
+	}
+
 	npns.gotNetNamespace = true
 	if npns.gotNamespace {
 		np.updateMatchCache(npns)
@@ -278,6 +297,8 @@ func (np *networkPolicyPlugin) DeleteNetNamespace(netns *osdnv1.NetNamespace) {
 	}
 	delete(np.namespaces, netns.NetID)
 	npns.gotNetNamespace = false
+
+	np.unProcessedVNIDs.Delete(int32(npns.vnid))
 
 	// We don't need to call refreshNetworkPolicies here; if the VNID doesn't get
 	// reused then the stale flows won't hurt anything, and if it does get reused then
@@ -531,7 +552,11 @@ func (np *networkPolicyPlugin) EnsureVNIDRules(vnid uint32) {
 	defer np.lock.Unlock()
 
 	npns, exists := np.namespaces[vnid]
-	if !exists || npns.inUse {
+	if !exists {
+		np.unProcessedVNIDs.Insert(int32(vnid))
+		return
+	}
+	if npns.inUse {
 		return
 	}
 
@@ -552,6 +577,7 @@ func (np *networkPolicyPlugin) SyncVNIDRules() {
 			npns.inUse = false
 			np.syncNamespace(npns)
 		}
+		np.unProcessedVNIDs.Delete(int32(vnid))
 	}
 }
 


### PR DESCRIPTION
There is a race condition where EnsureVNIDRules (via setup in pod.go) is invoked followed by AddNetNamespace which causes default vnid ingress and egress flow rules in table 80 and 27 not getting programmed. This fix ensures these flow rules are programmed though AddNetNamespace is processed at later point of time.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>
(cherry picked from commit 04e948660c4d165f87990d05ca227bc68ef46ce1)