### PR TITLE
OCPBUGS-6714: Initialize egress node monitoring struct with previous reachability status

### DIFF
--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -36,6 +36,12 @@ const (
 	// unlimitedNodeCapacity indicates a discarded capacity - useful on
 	// bare-metal where this is ignored.
 	unlimitedNodeCapacity = math.MaxInt32
+
+	// DefaultPollInterval default poll interval used for egress node reachability check
+	DefaultPollInterval = 5 * time.Second
+
+	// RepollInterval poll interval used for egress node reachability check retries
+	RepollInterval = time.Second
 )
 
 type ifAddr struct {

--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -102,7 +102,7 @@ type egressIPInfo struct {
 type EgressIPWatcher interface {
 	Synced()
 
-	ClaimEgressIP(vnid uint32, egressIP, nodeIP, sdnIP string)
+	ClaimEgressIP(vnid uint32, egressIP, nodeIP, sdnIP string, nodeOffline bool)
 	ReleaseEgressIP(egressIP, nodeIP string)
 
 	SetNamespaceEgressNormal(vnid uint32)
@@ -644,7 +644,7 @@ func (eit *EgressIPTracker) syncEgressNodeState(eg *egressIPInfo, active bool) {
 	if active && eg.assignedNodeIP != eg.nodes[0].nodeIP {
 		klog.V(4).Infof("Assigning egress IP %s to node %s", eg.ip, eg.nodes[0].nodeIP)
 		eg.assignedNodeIP = eg.nodes[0].nodeIP
-		eit.watcher.ClaimEgressIP(eg.namespaces[0].vnid, eg.ip, eg.assignedNodeIP, eg.nodes[0].sdnIP)
+		eit.watcher.ClaimEgressIP(eg.namespaces[0].vnid, eg.ip, eg.assignedNodeIP, eg.nodes[0].sdnIP, eg.nodes[0].offline)
 	} else if !active && eg.assignedNodeIP != "" {
 		klog.V(4).Infof("Removing egress IP %s from node %s", eg.ip, eg.assignedNodeIP)
 		eit.watcher.ReleaseEgressIP(eg.ip, eg.assignedNodeIP)
@@ -680,7 +680,7 @@ func (eit *EgressIPTracker) syncEgressNamespaceState(ns *namespaceEgress) {
 		eg.assignedVNID = ns.vnid
 		if eg.assignedNodeIP == "" {
 			klog.V(4).Infof("VNID %d cannot use unassigned egress IP %s", ns.vnid, eg.ip)
-		} else if len(ns.requestedIPs) > 1 && eg.nodes[0].offline {
+		} else if eg.nodes[0].offline {
 			klog.V(4).Infof("VNID %d cannot use egress IP %s on offline node %s", ns.vnid, eg.ip, eg.assignedNodeIP)
 		} else {
 			activeEgressIPs = append(activeEgressIPs, EgressIPAssignment{NodeIP: eg.assignedNodeIP, EgressIP: eg.ip})

--- a/pkg/network/common/egressip_test.go
+++ b/pkg/network/common/egressip_test.go
@@ -23,7 +23,7 @@ func (w *testEIPWatcher) Synced() {
 	panic("should not be reached in unit test")
 }
 
-func (w *testEIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP, sdnIP string) {
+func (w *testEIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP, sdnIP string, nodeOffline bool) {
 	w.changes = append(w.changes, fmt.Sprintf("claim %s on %s for namespace %d", egressIP, nodeIP, vnid))
 }
 

--- a/pkg/network/master/egressip.go
+++ b/pkg/network/master/egressip.go
@@ -295,7 +295,7 @@ func (eim *egressIPManager) Synced() {
 // until the previous assignment to node A has been fully removed. We thus need
 // to "queue" the create event and execute it once we observe the complete
 // removal of the delete using our informer.
-func (eim *egressIPManager) ClaimEgressIP(vnid uint32, egressIP, nodeIP, sdnIP string) {
+func (eim *egressIPManager) ClaimEgressIP(vnid uint32, egressIP, nodeIP, sdnIP string, nodeOffline bool) {
 	if !eim.tracker.CloudEgressIP {
 		return
 	}

--- a/pkg/network/master/egressip.go
+++ b/pkg/network/master/egressip.go
@@ -197,9 +197,7 @@ func (eim *egressIPManager) maybeDoUpdateEgressCIDRs() (bool, error) {
 }
 
 const (
-	pollInterval   = 5 * time.Second
-	repollInterval = time.Second
-	maxRetries     = 2
+	maxRetries = 2
 )
 
 func (eim *egressIPManager) poll(stop chan struct{}) {
@@ -217,8 +215,8 @@ func (eim *egressIPManager) poll(stop chan struct{}) {
 			klog.Warningf("Node may have been deleted or not exist anymore")
 		}
 		if !retry {
-			// If less than pollInterval has passed since start, then sleep until it has
-			time.Sleep(start.Add(pollInterval).Sub(time.Now()))
+			// If less than common.DefaultPollInterval has passed since start, then sleep until it has
+			time.Sleep(start.Add(common.DefaultPollInterval).Sub(time.Now()))
 		}
 	}
 }
@@ -238,9 +236,9 @@ func nodeIsReady(node *corev1.Node) bool {
 func (eim *egressIPManager) check(retrying bool) (bool, error) {
 	var timeout time.Duration
 	if retrying {
-		timeout = repollInterval
+		timeout = common.RepollInterval
 	} else {
-		timeout = pollInterval
+		timeout = common.DefaultPollInterval
 	}
 
 	needRetry := false

--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -21,8 +21,6 @@ import (
 )
 
 const (
-	defaultPollInterval   = 5 * time.Second
-	repollInterval        = time.Second
 	maxRetries            = 2
 	defaultKubeletDropBit = 1 << uint32(15) // https://github.com/kubernetes/kubelet/blob/release-1.24/config/v1beta1/types.go#L555
 )
@@ -212,7 +210,7 @@ func (eip *egressIPWatcher) runIPAssignmentResync(stopCh <-chan struct{}) {
 				if subscribeErr = addrSubscribe(); subscribeErr != nil {
 					klog.Error("Error during netlink re-subscribe due to address channel closing: %v", subscribeErr)
 					// limit the retry attempts
-					time.Sleep(defaultPollInterval)
+					time.Sleep(common.DefaultPollInterval)
 				}
 				continue
 			}
@@ -277,7 +275,7 @@ func (eip *egressIPWatcher) addEgressIP(nodeIP, egressIP, sdnIP string) {
 	}
 	if len(eip.monitorNodes) == 1 {
 		eip.stopMonitorNodes = make(chan struct{})
-		go utilwait.PollUntil(defaultPollInterval, eip.poll, eip.stopMonitorNodes)
+		go utilwait.PollUntil(common.DefaultPollInterval, eip.poll, eip.stopMonitorNodes)
 	}
 }
 
@@ -302,7 +300,7 @@ func (eip *egressIPWatcher) removeEgressIP(nodeIP, egressIP string) {
 func (eip *egressIPWatcher) poll() (bool, error) {
 	retry := eip.check(false)
 	for retry {
-		time.Sleep(repollInterval)
+		time.Sleep(common.RepollInterval)
 		retry = eip.check(true)
 	}
 	return false, nil
@@ -322,9 +320,9 @@ func (eip *egressIPWatcher) getOfflineResult(retrying bool) (map[string]bool, bo
 
 	var timeout time.Duration
 	if retrying {
-		timeout = repollInterval
+		timeout = common.RepollInterval
 	} else {
-		timeout = defaultPollInterval
+		timeout = common.DefaultPollInterval
 	}
 
 	needRetry := false

--- a/pkg/network/node/egressip.go
+++ b/pkg/network/node/egressip.go
@@ -224,7 +224,7 @@ func (eip *egressIPWatcher) runIPAssignmentResync(stopCh <-chan struct{}) {
 	}
 }
 
-func (eip *egressIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP, sdnIP string) {
+func (eip *egressIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP, sdnIP string, nodeOffline bool) {
 	if nodeIP == eip.localIP {
 		mark := getMarkForVNID(vnid, eip.masqueradeBit)
 		eip.iptablesMark[egressIP] = mark
@@ -237,7 +237,7 @@ func (eip *egressIPWatcher) ClaimEgressIP(vnid uint32, egressIP, nodeIP, sdnIP s
 			go eip.runIPAssignmentResync(eip.stopIPResync)
 		}
 	} else {
-		eip.addEgressIP(nodeIP, egressIP, sdnIP)
+		eip.addEgressIP(nodeIP, egressIP, sdnIP, nodeOffline)
 	}
 }
 
@@ -258,7 +258,7 @@ func (eip *egressIPWatcher) ReleaseEgressIP(egressIP, nodeIP string) {
 	}
 }
 
-func (eip *egressIPWatcher) addEgressIP(nodeIP, egressIP, sdnIP string) {
+func (eip *egressIPWatcher) addEgressIP(nodeIP, egressIP, sdnIP string, nodeOffline bool) {
 	eip.monitorNodesLock.Lock()
 	defer eip.monitorNodesLock.Unlock()
 
@@ -272,6 +272,7 @@ func (eip *egressIPWatcher) addEgressIP(nodeIP, egressIP, sdnIP string) {
 		nodeIP:    nodeIP,
 		sdnIP:     sdnIP,
 		egressIPs: sets.NewString(egressIP),
+		offline:   nodeOffline,
 	}
 	if len(eip.monitorNodes) == 1 {
 		eip.stopMonitorNodes = make(chan struct{})


### PR DESCRIPTION
There are two issues this PR tries to address:

[1] When egress node goes offline and there is **only one** egress IP assigned to a netnamespace the flows will not be removed from the node hosting a matching pod: 
    - in auto mode, the flow will get cleared once the sdn-controller removes the egress IP from the hostsubnet
    - in manual mode, the pod traffic will still be sent to the egress node


[2] When one egress node goes offline and there is **multiple** egress IPs assigned to a netnamespace the following could happen: 
1. On the pod node SDN detects the egress node as offline, sets `egressNode.offline` to true, and modifies the OVS flows:
```
I0210 13:55:25.625292  148815 egressip.go:350] Node 10.0.130.175 may be offline... retrying
I0210 13:55:27.626969  148815 egressip.go:350] Node 10.0.130.175 may be offline... retrying
W0210 13:55:29.627456  148815 egressip.go:345] Node 10.0.130.175 is offline
I0210 13:55:29.627493  148815 egressip.go:678] VNID 0 cannot use egress IP 10.0.128.101 on offline node 10.0.130.175
```
2. sdn-controller removes the affected egress IP from the hostsubnet:
```
I0210 13:55:37.622737  148815 egressip.go:238] Watch MODIFIED event for HostSubnet "ip-10-0-130-175.ec2.internal"
I0210 13:55:37.622791  148815 subnets.go:47] Watch MODIFIED event for HostSubnet "ip-10-0-130-175.ec2.internal"
I0210 13:55:37.628057  148815 egressip.go:643] Removing egress IP 10.0.128.101 from node 10.0.130.175
I0210 13:55:37.628079  148815 egressip.go:293] Unmonitoring node 10.0.130.175
I0210 13:55:37.628084  148815 egressip.go:676] VNID 0 cannot use unassigned egress IP 10.0.128.101
```
  5. Egress node comes online.
  6. sdn-controller add the egress IP back to the node.
  8. On the pod node SDN calls `ClaimEgressIP` but does not adapt the flows because `egressNode.offline` is still set to true:
```
I0210 13:55:43.643621  148815 egressip.go:238] Watch MODIFIED event for HostSubnet "ip-10-0-130-175.ec2.internal"
I0210 13:55:43.643631  148815 subnets.go:47] Watch MODIFIED event for HostSubnet "ip-10-0-130-175.ec2.internal"
I0210 13:55:43.649829  148815 egressip.go:639] Assigning egress IP 10.0.128.101 to node 10.0.130.175
I0210 13:55:43.649848  148815 egressip.go:271] Monitoring node 10.0.130.175
I0210 13:55:43.649852  148815 egressip.go:678] VNID 0 cannot use egress IP 10.0.128.101 on offline node 10.0.130.175
```



To address the first issue always check whether the egress node is offline or not before configuring the OVS flows, regardless of the number of egress IPs assigned to the netnamespace. 
To address the second issue use `egressNode.offline` to initialize the egress node monitoring struct so SDN can react to reachability change properly.

**Reproduction steps (the issue doesn't always occur):**
1. Create a namespace with a pod.
2. Patch two hostsubnets with `egressCIDRs` (don't use the pod node).
3. Assign two egress IPs to the previously created namespace.
4. Reboot the first egress node and wait for the egress IP to get assigned back to it.
5. Reboot the second egress node and wait for the egress IP to get assigned back to it.
6. Check external connectivity from a pod created in step 1.

Signed-off-by: Patryk Diak <pdiak@redhat.com>