### PR TITLE
Drop non-conntrack-based Service support

### DIFF
--- a/pkg/cmd/openshift-sdn-node/kube_proxy.go
+++ b/pkg/cmd/openshift-sdn-node/kube_proxy.go
@@ -118,7 +118,6 @@ func newProxyServer(config *kubeproxyconfig.KubeProxyConfiguration, client clien
 	klog.V(0).Infof("kube-proxy running in single-stack %s mode", iptInterface.Protocol())
 
 	if proxyMode == proxyModeIPTables {
-		// userspace proxy mode was removed upstream in 1.26,
 		klog.V(0).Info("Using iptables Proxier.")
 		if config.IPTables.MasqueradeBit == nil {
 			// MasqueradeBit must be specified or defaulted.

--- a/pkg/network/node/iptables_test.go
+++ b/pkg/network/node/iptables_test.go
@@ -18,7 +18,7 @@ func TestVxlanNoTrackRulesWithCustomVxlanPort(t *testing.T) {
 
 func validateIPTableRuleForVxlanPort(t *testing.T, dstPort uint32) {
 	ipt := iptablestest.NewFake()
-	nodeIpt := newNodeIPTables(ipt, nil, true, dstPort, uint32(0))
+	nodeIpt := newNodeIPTables(ipt, nil, dstPort, uint32(0))
 	err := nodeIpt.syncIPTableRules()
 	if err != nil {
 		t.Fatalf("unexpected error while syncing ip table rules: %v", err)

--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/openshift/sdn/pkg/network/common"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/component-helpers/node/util/sysctl"
@@ -206,19 +205,5 @@ func (plugin *OsdnNode) updateEgressNetworkPolicyRules(vnid uint32) {
 	namespaces := plugin.policy.GetNamespaces(vnid)
 	if err := plugin.oc.UpdateEgressNetworkPolicyRules(policies, vnid, namespaces, plugin.egressDNS); err != nil {
 		klog.Errorf("Error updating OVS flows for EgressNetworkPolicy: %v", err)
-	}
-}
-
-func (plugin *OsdnNode) AddServiceRules(service *corev1.Service, netID uint32) {
-	klog.V(5).Infof("AddServiceRules for %v", service)
-	if err := plugin.oc.AddServiceRules(service, netID); err != nil {
-		klog.Errorf("Error adding OVS flows for service %v, netid %d: %v", service, netID, err)
-	}
-}
-
-func (plugin *OsdnNode) DeleteServiceRules(service *corev1.Service) {
-	klog.V(5).Infof("DeleteServiceRules for %v", service)
-	if err := plugin.oc.DeleteServiceRules(service); err != nil {
-		klog.Errorf("Error deleting OVS flows for service %v: %v", service, err)
 	}
 }


### PR DESCRIPTION
This was only used for Multitenant mode when using the userspace proxy. But the userspace proxy is gone now, so just remove the pre-conntrack codepaths.

(This also changes Subnet mode to use conntrack mode, but that's pretty much irrelevant.)

/assign @msherif1234 