### PR TITLE
OCPBUGS-8007: Fix race in Egress IP Tracker start

### DIFF
--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -151,11 +151,11 @@ func NewEgressIPTracker(watcher EgressIPWatcher, cloudEgressIP bool, localIP str
 
 func (eit *EgressIPTracker) Start(kubeClient kubernetes.Interface, hostSubnetInformer osdninformers.HostSubnetInformer, netNamespaceInformer osdninformers.NetNamespaceInformer, nodeInformer kcoreinformers.NodeInformer) {
 
+	eit.kubeClient = kubeClient
 	eit.watchHostSubnets(hostSubnetInformer)
 	eit.watchNetNamespaces(netNamespaceInformer)
 
 	if nodeInformer != nil {
-		eit.kubeClient = kubeClient
 		eit.watchNodes(nodeInformer)
 	}
 


### PR DESCRIPTION
This PR fixes issue tracked via [OCPBUGS-8007](https://issues.redhat.com/browse/OCPBUGS-8007): 

`nil pointer reference on egress IP puts sdn-controllers into crashloop after upgrading to Openshift 4.10.43`

This race is hard to reproduce on it's own, but can be easily reproduced in environments where CNCC is used, by adding an artificial delay in the start function as shown:

```
diff --git a/pkg/network/common/egressip.go b/pkg/network/common/egressip.go
index 56d3f0c32..22616bdaf 100644
--- a/pkg/network/common/egressip.go
+++ b/pkg/network/common/egressip.go
@@ -147,7 +147,11 @@ func (eit *EgressIPTracker) Start(kubeClient kubernetes.Interface, hostSubnetInf
        eit.watchNetNamespaces(netNamespaceInformer)        if nodeInformer != nil {
+               time.Sleep(10 * time.Second)
                eit.kubeClient = kubeClient
                eit.watchNodes(nodeInformer)
        }
```