### PR TITLE
OCPBUGS-12435: EgressNetworkPolicy DNS resolution does not fall back to TCP

### DIFF
--- a/pkg/network/common/dns.go
+++ b/pkg/network/common/dns.go
@@ -216,6 +216,15 @@ func (d *DNS) doOneQuery(server, domain string, rtype uint16) ([]net.IP, int, er
 	c := new(dns.Client)
 	c.Timeout = d.timeout
 	in, _, err := c.Exchange(msg, server)
+	// check if message truncated
+	if in != nil && in.Truncated {
+		// if it is fall back to TCP
+		c.Net = "tcp"
+		//ensure that the old message is overwritten
+		msg = new(dns.Msg)
+		msg.SetQuestion(dns.Fqdn(domain), rtype)
+		in, _, err = c.Exchange(msg, server)
+	}
 	if in == nil || err != nil {
 		return ips, ttl, err
 	}


### PR DESCRIPTION
DNS resolution has a fixed buffer size of 512 and when getting a DNS response that is to large for the buffer the response is truncated and in general systems fall back to a TCP dns request. Currently we do not fall back to that TCP dns request.

Add the fall back TCP DNS request when the original UDP request returns a truncated response. In addition I do not use the ErrTruncated to test for a truncated message because eventually the library gets rid of that error in favor of checking the Truncated flag in the message.