### PR TITLE
[release-4.10] OCPBUGS-13919: save and delete the old egress network policy

### DIFF
--- a/pkg/network/node/egress_network_policy.go
+++ b/pkg/network/node/egress_network_policy.go
@@ -75,10 +75,10 @@ func (plugin *OsdnNode) handleEgressNetworkPolicy(policy *osdnv1.EgressNetworkPo
 	for i, oldPolicy := range policies {
 		if oldPolicy.UID == policy.UID {
 			policies = append(policies[:i], policies[i+1:]...)
+			plugin.egressDNS.Delete(oldPolicy)
 			break
 		}
 	}
-	plugin.egressDNS.Delete(*policy)
 
 	if eventType != watch.Deleted && len(policy.Spec.Egress) > 0 {
 		policies = append(policies, *policy)


### PR DESCRIPTION
When egress network policies are updated they are deleted and recreated. When we are processing the update for egress network policies currently we delete the new version of the network policy as opposed to the old version. If a dnsName is being removed from an egress network policy during an update the dnsName is not in the most recent version of the object and it will not be removed from the egress network policies egressDNS maps.

Plug the leaked data by ensuring that we delete the previous version of the egressNetwork policy and correctly remove the DNS names from the egressDNS object.

manual cherry-pick of https://github.com/openshift/sdn/pull/544 to move things along faster