### PR TITLE
OCPBUGS-3176: Enable IP Forwarding if disabled

### DIFF
--- a/pkg/network/node/sdn_controller.go
+++ b/pkg/network/node/sdn_controller.go
@@ -103,12 +103,17 @@ func deleteLocalSubnetRoute(device, localSubnetCIDR string) {
 func (plugin *OsdnNode) SetupSDN() (bool, map[string]podNetworkInfo, error) {
 	// Make sure IPv4 forwarding state is 1
 	sysctl := sysctl.New()
-	val, err := sysctl.GetSysctl("net/ipv4/ip_forward")
+	sysIPForward := "net/ipv4/ip_forward"
+	val, err := sysctl.GetSysctl(sysIPForward)
 	if err != nil {
 		return false, nil, fmt.Errorf("could not get IPv4 forwarding state: %s", err)
 	}
 	if val != 1 {
-		return false, nil, fmt.Errorf("net/ipv4/ip_forward=0, it must be set to 1")
+		klog.Infof("Global IP Forwarding is disabled. Enabling...")
+		err := sysctl.SetSysctl(sysIPForward, 1)
+		if err != nil {
+			return false, nil, fmt.Errorf("cannot enable IP Forwarding via sysctl: %v", err)
+		}
 	}
 
 	localSubnetCIDR := plugin.localSubnetCIDR


### PR DESCRIPTION
With changes to disable IP forwarding by default with OVNK: https://github.com/openshift/machine-config-operator/pull/3676

OVN to SDN migration is now broken, because pods roll out first that require IP forwarding. IP forwarding for SDN is enabled via MCO node rollout, which happens later.

This change enables IP forwarding in the SDN pod itself if needed.