### PR TITLE
[release-4.11] OCPBUGS-14305: fix possible concurrent map read/write

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -1028,6 +1028,9 @@ func (np *networkPolicyPlugin) handleAddOrUpdatePod(obj, old interface{}, eventT
 	pod := obj.(*corev1.Pod)
 	klog.V(5).Infof("Watch %s event for Pod %q", eventType, getPodFullName(pod))
 
+	np.lock.Lock()
+	defer np.lock.Unlock()
+
 	if !np.isOnPodNetwork(pod) {
 		return
 	}
@@ -1039,8 +1042,6 @@ func (np *networkPolicyPlugin) handleAddOrUpdatePod(obj, old interface{}, eventT
 		}
 	}
 
-	np.lock.Lock()
-	defer np.lock.Unlock()
 	if np.localPodIPs[pod.UID] != "" && pod.Status.PodIP != "" {
 		// cleanup local pod ip once pod.Status.PodIP is set
 		delete(np.localPodIPs, pod.UID)


### PR DESCRIPTION
manual cherry-pick of https://github.com/openshift/sdn/pull/546

there is a potential concurrent map read/write in handleAddOrUpdatePod() in pkg/network/node/networkpolicy.go

handleAddOrUpdatePod() has to get the networkPolicyPlugin lock before calling isOnPodNetwork() because that can call getPodIP() which reads the localPodIPs map. If the lock is not grabbed there could be a concurrent read/write of the map

this patch grabs the lock before calling isOnPodNetwork()