### PR TITLE
OCPBUGS-15977: Dockerfile: keep a RHEL-8 CNI shim binary in the default /opt/cni/bin dir

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -19,6 +19,7 @@ COPY --from=rhel9-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /op
 RUN mkdir -p /opt/cni/bin/rhel8
 COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-node /usr/bin/
 COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-controller /usr/bin/
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/openshift-sdn
 COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/rhel8/openshift-sdn
 COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
 


### PR DESCRIPTION
Ensure that we keep a binary at the same place as the older images just in case something expects it there. Really only affects CI due to the way we run our CI upgrade jobs by hacking around with the CNO manifests.