### PR TITLE
Dockerfile changes to build both rhel8 and rhel9 binaries

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -21,6 +21,7 @@ COPY --from=rhel9-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /op
 RUN mkdir -p /opt/cni/bin/rhel8
 COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-node /usr/bin/
 COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-controller /usr/bin/
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/openshift-sdn
 COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/rhel8/openshift-sdn
 COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
 

--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -1,18 +1,28 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS rhel9-builder
 WORKDIR /go/src/github.com/openshift/sdn
 COPY . .
 RUN make build --warn-undefined-variables
-RUN CGO_ENABLED=0 GO_BUILD_FLAGS="-tags no_openssl" make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/openshift-sdn-cni" --warn-undefined-variables
+RUN CGO_ENABLED=1 make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/openshift-sdn-cni" --warn-undefined-variables
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS rhel8-builder
+WORKDIR /go/src/github.com/openshift/sdn
+COPY . .
+RUN make build --warn-undefined-variables
+RUN CGO_ENABLED=1 make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/openshift-sdn-cni" --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.14:cli AS cli
 FROM registry.ci.openshift.org/ocp/4.14:base
 
 ARG ovsver=2.13
 
-COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn-node /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn-controller /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/openshift-sdn
-COPY --from=builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
+RUN mkdir -p /opt/cni/bin/rhel9
+COPY --from=rhel9-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/rhel9/openshift-sdn
+
+RUN mkdir -p /opt/cni/bin/rhel8
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-node /usr/bin/
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-controller /usr/bin/
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/rhel8/openshift-sdn
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
 
 COPY --from=cli /usr/bin/oc /usr/bin/
 


### PR DESCRIPTION
Dockerfile changes to build both rhel8 and rhel9 binaries

Since the shim (openshift-sdn) gets copied to the host OS and
executed in the host mount namespace by CRIO/Multus it needs
to be runtime compatible with the host OS. Running a RHEL9-built
shim on a RHEL8 system doesn't work due to different shared library
dependencies between the two OS versions.

This wasn't a problem before because CGO_ENABLED=0 which essentially
statically linked everything into the binary. But since we actually
need CGO_ENABLED=1 (which ART forces on "official" builds anyway)
to ensure we use OpenSSL's crypto for FIPS compliance, we run into
the OS version problem with our binaries since they are really
always built with CGO_ENABLED=1 anyway.

So... build two separate versions of openshift-sdn and
osdn-host-local (which is invoked by openshift-sdn shim) in
different layers, and copy the shims into a special location where
our container startup scripts can find it.