### PR TITLE
[release-4.6] OCPBUGS-16255: Dockerfile changes to build both rhel7 and rhel8 binaries

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -1,14 +1,25 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS rhel8-builder
 WORKDIR /go/src/github.com/openshift/sdn
 COPY . .
 RUN make build --warn-undefined-variables
-RUN CGO_ENABLED=0 GO_BUILD_FLAGS="-tags no_openssl" make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/sdn-cni-plugin" --warn-undefined-variables
+RUN CGO_ENABLED=1 make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/sdn-cni-plugin" --warn-undefined-variables
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.15-openshift-4.6 AS rhel7-builder
+WORKDIR /go/src/github.com/openshift/sdn
+COPY . .
+RUN make build --warn-undefined-variables
+RUN CGO_ENABLED=1 make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/sdn-cni-plugin" --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.6:base
-COPY --from=builder /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/openshift-sdn-node
-COPY --from=builder /go/src/github.com/openshift/sdn/network-controller /usr/bin/openshift-sdn-controller
-COPY --from=builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/openshift-sdn
-COPY --from=builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
+RUN mkdir -p /opt/cni/bin/rhel8
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn /usr/bin/openshift-sdn-node
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/network-controller /usr/bin/openshift-sdn-controller
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/openshift-sdn
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/rhel8/openshift-sdn
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
+
+RUN mkdir -p /opt/cni/bin/rhel7
+COPY --from=rhel7-builder /go/src/github.com/openshift/sdn/sdn-cni-plugin /opt/cni/bin/rhel7/openshift-sdn
 
 RUN INSTALL_PKGS=" \
       openvswitch2.13 container-selinux socat ethtool nmap-ncat \


### PR DESCRIPTION
Since the shim (openshift-sdn) gets copied to the host OS and executed in the host mount namespace by CRIO/Multus it needs to be runtime compatible with the host OS. Running a RHEL8-built shim on a RHEL7 system doesn't work due to different shared library dependencies between the two OS versions.

This wasn't a problem before because CGO_ENABLED=0 which essentially statically linked everything into the binary. But since we actually need CGO_ENABLED=1 (which ART forces on "official" builds anyway) to ensure we use OpenSSL's crypto for FIPS compliance, we run into the OS version problem with our binaries since they are really always built with CGO_ENABLED=1 anyway.

So... build two separate versions of openshift-sdn and osdn-host-local (which is invoked by openshift-sdn shim) in different layers, and copy the shims into a special location where our container startup scripts can find it.

Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
(cherry picked from commit 8fe1a62f940b2f8b6a5ac9f1f4ab6a57572ff75a) (cherry picked from commit b3fd83d5858512ee16a1cb448d7ad0e57c46ccd6) (cherry picked from commit 26d495582f6bef7016b9304fea27de96957a1bc3)