### PR TITLE
[release-4.13] OCPBUGS-14504: Use the ovsver build arg to infer the openvswitch short version number

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -13,6 +13,7 @@ RUN CGO_ENABLED=1 make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/ope
 FROM registry.ci.openshift.org/ocp/4.13:cli AS cli
 FROM registry.ci.openshift.org/ocp/4.13:base
 
+ARG ovsver=2.13
 RUN mkdir -p /opt/cni/bin/rhel9
 COPY --from=rhel9-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/rhel9/openshift-sdn
 
@@ -26,7 +27,7 @@ COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/host-local /usr/bin/c
 COPY --from=cli /usr/bin/oc /usr/bin/
 
 RUN INSTALL_PKGS=" \
-      openvswitch2.13 container-selinux socat ethtool nmap-ncat \
+      openvswitch${ovsver} container-selinux socat ethtool nmap-ncat \
       libmnl libnetfilter_conntrack conntrack-tools \
       libnfnetlink iproute procps-ng openssl \
       iputils binutils xz util-linux dbus nftables \


### PR DESCRIPTION
This is an cherry-pick of https://github.com/openshift/sdn/pull/534 instead of https://github.com/openshift/sdn/pull/553