### PR TITLE
OCPBUGS-16788: Create IPAM files with 0600 permissions

### DIFF
--- a/deps.diff
+++ b/deps.diff
@@ -1,0 +1,9 @@
+diff --no-dereference -N -r current/vendor/github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk/backend.go updated/vendor/github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk/backend.go
+59c59
+< 	f, err := os.OpenFile(fname, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0600)
+---
+> 	f, err := os.OpenFile(fname, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0644)
+77c77
+< 	err = ioutil.WriteFile(ipfile, []byte(ip.String()), 0600)
+---
+> 	err = ioutil.WriteFile(ipfile, []byte(ip.String()), 0644)

--- a/vendor/github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk/backend.go
+++ b/vendor/github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk/backend.go
@@ -56,7 +56,7 @@ func New(network, dataDir string) (*Store, error) {
 
 func (s *Store) Reserve(id string, ip net.IP, rangeID string) (bool, error) {
 	fname := filepath.Join(s.dataDir, ip.String())
-	f, err := os.OpenFile(fname, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0644)
+	f, err := os.OpenFile(fname, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0600)
 	if os.IsExist(err) {
 		return false, nil
 	}
@@ -74,7 +74,7 @@ func (s *Store) Reserve(id string, ip net.IP, rangeID string) (bool, error) {
 	}
 	// store the reserved ip in lastIPFile
 	ipfile := filepath.Join(s.dataDir, lastIPFilePrefix+rangeID)
-	err = ioutil.WriteFile(ipfile, []byte(ip.String()), 0644)
+	err = ioutil.WriteFile(ipfile, []byte(ip.String()), 0600)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Conform to CIS Benchmarks "1.1.9 Ensure that the Container Network Interface file permissions are set to 600 or more restrictive" https://www.tenable.com/audits/items/CIS_Kubernetes_v1.20_v1.0.1_Level_1_Master.audit:f1717a5dd65d498074dd41c4a639e47d

The fix was merged in containernetworking/plugin (https://github.com/containernetworking/plugins/commit/33ccedc66fc30523f11d480d9d32f33c059fab7d), but we're vendoring a much older version of that repo in sdn and bumping containernetworking/plugins to the latest proved to be not straightforward (https://github.com/openshift/sdn/pull/579) and potentially prone to... regressions.

Let's just apply the small fix directly in the vendored repo to avoid issues.