### PR TITLE
Remove .ci-operator.yaml

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  name: release
-  namespace: openshift
-  tag: rhel-8-release-golang-1.21-openshift-4.16

--- a/deps.diff
+++ b/deps.diff
@@ -1,9 +1,0 @@
-diff --no-dereference -N -r current/vendor/github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk/backend.go updated/vendor/github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk/backend.go
-59c59
-< 	f, err := os.OpenFile(fname, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0600)
----
-> 	f, err := os.OpenFile(fname, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0644)
-77c77
-< 	err = ioutil.WriteFile(ipfile, []byte(ip.String()), 0600)
----
-> 	err = ioutil.WriteFile(ipfile, []byte(ip.String()), 0644)


### PR DESCRIPTION
The .ci-operator.yaml to customize the build of the root CI pipeline image. ART automation keeps trying to update this file between RHEL 8 & 9 just because we use those different versions to build the sdn and kube proxy images. AFAIK we don't use the root image in SDN CI so just remove it to avoid the hassle.

Also remove deps.diff which looks like was merged unintentionally.