### PR TITLE
TRT-1481: Revert #613 "OCPBUGS-28580: Move sdn to RHEL9 base image"

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -11,19 +11,19 @@ RUN make build --warn-undefined-variables
 RUN CGO_ENABLED=1 make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/openshift-sdn-cni" --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.15:cli AS cli
-FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.15:base
 
-ARG ovsver=3.1
-
-RUN mkdir -p /opt/cni/bin/rhel8
-COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/rhel8/openshift-sdn
+ARG ovsver=2.13
 
 RUN mkdir -p /opt/cni/bin/rhel9
-COPY --from=rhel9-builder /go/src/github.com/openshift/sdn/openshift-sdn-node /usr/bin/
-COPY --from=rhel9-builder /go/src/github.com/openshift/sdn/openshift-sdn-controller /usr/bin/
-COPY --from=rhel9-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/openshift-sdn
 COPY --from=rhel9-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/rhel9/openshift-sdn
-COPY --from=rhel9-builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
+
+RUN mkdir -p /opt/cni/bin/rhel8
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-node /usr/bin/
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-controller /usr/bin/
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/openshift-sdn
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/rhel8/openshift-sdn
+COPY --from=rhel8-builder /go/src/github.com/openshift/sdn/host-local /usr/bin/cni/osdn-host-local
 
 COPY --from=cli /usr/bin/oc /usr/bin/
 


### PR DESCRIPTION

Reverts #613 ; tracked by TRT-1481

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

We're seeing 100% failures on certain sdn jobs that appear to be tracing back to: openshift-sdn-controller: /lib64/libc.so.6: version GLIBC_2.34 not found (required by openshift-sdn-controller).

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-sdn-upgrade should expose this problem, but there could be oddities because this is a Dockerfile change, it may not always be picked up. It is worth trying though after a fix can be attempted.
```

CC: @jcaamano

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
