### PR TITLE
OCPBUGS-26084: Fix scan issue

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,5 +4,6 @@
 exclude:
   global:
     - vendor/golang.org/x/net/http2
+    - vendor/github.com/containernetworking/plugins/pkg/ns/ns_linux.go
     - images/**
     - .ci-operator.yaml


### PR DESCRIPTION
ignore vendor/github.com/containernetworking/plugins/pkg/ns/ns_linux.go to supress scan errors in snyk scan