### PR TITLE
ART sync and golang 1.22 update

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/sdn
 
-go 1.21
+go 1.22
 
 require (
 	github.com/containernetworking/cni v0.8.1

--- a/images/kube-proxy/Dockerfile.rhel
+++ b/images/kube-proxy/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/sdn
 COPY . .
 RUN make build --warn-undefined-variables

--- a/pkg/network/node/node.go
+++ b/pkg/network/node/node.go
@@ -381,7 +381,7 @@ func (node *OsdnNode) reattachPods(existingPodSandboxes map[string]*kruntimeapi.
 		return err
 	}
 	start := time.Now()
-	defer klog.V(2).Infof("reattachPods took %v", time.Since(start))
+	defer func() { klog.V(2).Infof("reattachPods took %v", time.Since(start)) }()
 	node.podManager.setReattachPodsCache(pods)
 	for sandboxID, podInfo := range existingOFPodNetworks {
 		sandbox, ok := existingPodSandboxes[sandboxID]


### PR DESCRIPTION
Pulls in #625 and fixes the `make verify` bug with new golang