### PR TITLE
OCPBUGS-43193: CVE-2024-21626: Bump runc from v1.1.10 to v1.1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gorilla/mux v1.8.0
 	github.com/miekg/dns v1.1.35
-	github.com/opencontainers/runc v1.1.10
+	github.com/opencontainers/runc v1.1.12
 	github.com/openshift/api v0.0.0-20231010075512-1ccc6058c62d
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -273,7 +273,7 @@ github.com/mxk/go-flowrate/flowrate
 # github.com/opencontainers/go-digest v1.0.0 => github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
-# github.com/opencontainers/runc v1.1.10 => github.com/opencontainers/runc v1.0.0-rc95
+# github.com/opencontainers/runc v1.1.12 => github.com/opencontainers/runc v1.0.0-rc95
 ## explicit; go 1.13
 github.com/opencontainers/runc/libcontainer/cgroups
 github.com/opencontainers/runc/libcontainer/cgroups/fscommon


### PR DESCRIPTION
- Bump `github.com/opencontainers/runc` from `v1.1.10` to `v1.1.12`