### PR TITLE
[release-4.15] OCPBUGS-43605: backport fix for network policy during live migration

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net"
 	"os"
 	"reflect"
 	"sort"
@@ -822,7 +823,8 @@ func (np *networkPolicyPlugin) parsePeerFlows(npns *npNamespace, npp *npPolicy, 
 					sel, _ := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
 					if _, ok := np.nsMatchCache[sel.String()].matches[HostNetworkNamespace]; ok {
 						for _, network := range np.node.networkInfo.ClusterNetworks {
-							cidrIP := network.ClusterCIDR.IP
+							cidrIP := make(net.IP, len(network.ClusterCIDR.IP))
+							copy(cidrIP, network.ClusterCIDR.IP)
 							cidrIP[3] = cidrIP[3] | 0x2
 							maskLen, _ := network.ClusterCIDR.Mask.Size()
 							// use a mask to match the OVN mp0 IP which is the second IP of each host subnet.

--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -183,7 +183,7 @@ const (
 	Vxlan0 = "vxlan0"
 
 	// rule versioning; increment each time flow rules change
-	ruleVersion = 13
+	ruleVersion = 14
 
 	ruleVersionTable = 253
 )

--- a/pkg/network/node/ovscontroller_test.go
+++ b/pkg/network/node/ovscontroller_test.go
@@ -1060,7 +1060,7 @@ var expectedFlows = []string{
 	" cookie=0, table=111, priority=100, actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:10.0.123.45->tun_dst,output:1,set_field:10.0.45.123->tun_dst,output:1,goto_table:120",
 	" cookie=0, table=120, priority=100, reg0=99, actions=output:4,output:5,output:6",
 	" cookie=0, table=120, priority=0, actions=drop",
-	" cookie=0, table=253, actions=note:00.0D",
+	" cookie=0, table=253, actions=note:00.0E",
 }
 
 // Ensure that we do not change the OVS flows without bumping ruleVersion


### PR DESCRIPTION
This is a clean cherry-pick with 1d1d0ba19 and fd03ac23c