### PR TITLE
OCPBUGS-45806: Stop checking ruleVersion [4.16]

### DIFF
--- a/pkg/network/node/ovscontroller.go
+++ b/pkg/network/node/ovscontroller.go
@@ -182,9 +182,6 @@ const (
 	Tun0   = "tun0"
 	Vxlan0 = "vxlan0"
 
-	// rule versioning; increment each time flow rules change
-	ruleVersion = 14
-
 	ruleVersionTable = 253
 )
 
@@ -193,10 +190,7 @@ func NewOVSController(ovsif ovs.Interface, pluginId int, localIP string, localMA
 }
 
 func (oc *ovsController) getVersionNote() string {
-	if ruleVersion > 254 {
-		panic("Version too large!")
-	}
-	return fmt.Sprintf("%02X.%02X", oc.pluginId, ruleVersion)
+	return fmt.Sprintf("%02X", oc.pluginId)
 }
 
 func (oc *ovsController) AlreadySetUp(vxlanPort uint32) bool {


### PR DESCRIPTION
At some point things seem to have broken such that doing a "full setup" ends up breaking the node until you restart all the pods.

Since all upgradeable-from versions have basically equivalent OVS flows, just remove the ruleVersion check, so that we never have to do a "full setup" for that reason.

In particular, although I thought we needed a bump from ruleVersion 13 to 14 for the OVN migration fix, it was actually unnecessary; we already rewrite all NetworkPolicy rules on restart anyway (and even if we didn't, we need to rewrite them when you switch between regular mode and migration mode, not when you first upgrade to the release that supports migration).

/assign @pliurh 