### PR TITLE
OCPBUGS-46536: Bump openvswitch

### DIFF
--- a/images/sdn/Dockerfile.rhel
+++ b/images/sdn/Dockerfile.rhel
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=1 make build GO_BUILD_PACKAGES="github.com/openshift/sdn/cmd/ope
 FROM registry.ci.openshift.org/ocp/4.14:cli AS cli
 FROM registry.ci.openshift.org/ocp/4.14:base
 
-ARG ovsver=2.13
+ARG ovsver=2.17
 
 RUN mkdir -p /opt/cni/bin/rhel9
 COPY --from=rhel9-builder /go/src/github.com/openshift/sdn/openshift-sdn-cni /opt/cni/bin/rhel9/openshift-sdn


### PR DESCRIPTION
- Bump openvswitch from `2.13` to `2.17` to mitigate CVE-2019-25076