### PR TITLE
OCPBUGS-46493: Raise the minSyncPeriod for NetworkPolicies to 10s during migration

### DIFF
--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -189,10 +189,23 @@ func (np *networkPolicyPlugin) Start(node *OsdnNode) error {
 		return err
 	}
 
-	// Rate-limit calls to np.syncFlows to 1-per-second after the 2nd call within 1
-	// second. The maxInterval (time.Hour) is irrelevant here because we always call
-	// np.runner.Run() if there is syncing to be done.
-	np.runner = async.NewBoundedFrequencyRunner("NetworkPolicy", np.syncFlows, time.Second, time.Hour, 2)
+	// Rate-limit calls to np.syncFlows to once per minSyncPeriod. The maxInterval
+	// (time.Hour) is irrelevant here because we always call np.runner.Run() if there
+	// is syncing to be done.
+	minSyncPeriod := time.Second
+	if np.inMigrationMode {
+		// The existing code can't keep up with the churn rate in large clusters
+		// when in migration mode.
+		allSubnets, err := np.node.osdnClient.NetworkV1().HostSubnets().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			klog.Warningf("Unexpected error trying to list HostSubnets (%v); assuming large cluster", err)
+			minSyncPeriod = 10 * time.Second
+		} else if len(allSubnets.Items) > 100 {
+			klog.Infof("Cluster has %d nodes; using slow NetworkPolicy resync mode for migration", len(allSubnets.Items))
+			minSyncPeriod = 10 * time.Second
+		}
+	}
+	np.runner = async.NewBoundedFrequencyRunner("NetworkPolicy", np.syncFlows, minSyncPeriod, time.Hour, 1)
 	go np.runner.Loop(utilwait.NeverStop)
 
 	if err := np.initNamespaces(); err != nil {

--- a/pkg/network/node/networkpolicy.go
+++ b/pkg/network/node/networkpolicy.go
@@ -820,8 +820,14 @@ func (np *networkPolicyPlugin) parsePeerFlows(npns *npNamespace, npp *npPolicy, 
 
 					// If the host network namespace is selected, Add rules for
 					// the OVN mp0 IP of each node.
+					hostNetworkSelected := false
 					sel, _ := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
-					if _, ok := np.nsMatchCache[sel.String()].matches[HostNetworkNamespace]; ok {
+					for _, vnid := range np.selectNamespacesInternal(sel) {
+						if vnid == 0 {
+							hostNetworkSelected = true
+						}
+					}
+					if hostNetworkSelected {
 						for _, network := range np.node.networkInfo.ClusterNetworks {
 							cidrIP := make(net.IP, len(network.ClusterCIDR.IP))
 							copy(cidrIP, network.ClusterCIDR.IP)

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -890,6 +890,65 @@ func TestNetworkPolicy(t *testing.T) {
 		t.Error(err.Error())
 	}
 
+	// Deleting pods should trigger recalculation of namespaces that watch those pods
+	synced.Store(false)
+	err = np.node.kClient.CoreV1().Pods(np.namespaces[3].name).Delete(context.TODO(), "client", metav1.DeleteOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("Unexpected error deleting client pod: %v", err))
+	}
+	err = np.node.kClient.CoreV1().Pods(np.namespaces[4].name).Delete(context.TODO(), "client", metav1.DeleteOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("Unexpected error deleting client pod: %v", err))
+	}
+	waitForSync(np, synced, "pod deletion")
+
+	err = assertPolicies(np, npns1, 5, map[string]*npPolicy{
+		"allow-from-even": {
+			watchesNamespaces: true,
+			watchesAllPods:    false,
+			watchesOwnPods:    false,
+			ingressFlows: []string{
+				"reg0=4",
+				"reg0=6",
+				"reg0=8",
+			},
+		},
+		"allow-from-odd-primes": {
+			watchesNamespaces: true,
+			watchesAllPods:    true,
+			watchesOwnPods:    true,
+			ingressFlows: []string{
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[5])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[7])),
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	err = assertPolicies(np, np.namespaces[3], 3, map[string]*npPolicy{
+		"allow-client-to-server": {
+			watchesNamespaces: false,
+			watchesAllPods:    false,
+			watchesOwnPods:    true,
+			ingressFlows:      []string{},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	err = assertPolicies(np, np.namespaces[4], 2, map[string]*npPolicy{
+		"allow-client-to-server": {
+			watchesNamespaces: false,
+			watchesAllPods:    false,
+			watchesOwnPods:    true,
+			ingressFlows:      []string{},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
 	// Create the special namespace that indicates host network traffic
 	addNamespace(np, "openshift-host-network", 200, map[string]string{"network.openshift.io/policy-group": "ingress"})
 	// Create the namespace to add network policy for
@@ -1537,6 +1596,71 @@ func TestNetworkPolicyInMigrationMode(t *testing.T) {
 			ingressFlows: []string{
 				"reg0=0",
 			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// Deleting a pod should trigger recalculation of namespaces that watch that pod
+	synced.Store(false)
+	err = np.node.kClient.CoreV1().Pods(np.namespaces[3].name).Delete(context.TODO(), "client", metav1.DeleteOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("Unexpected error deleting client pod: %v", err))
+	}
+	err = np.node.kClient.CoreV1().Pods(np.namespaces[4].name).Delete(context.TODO(), "client", metav1.DeleteOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("Unexpected error deleting client pod: %v", err))
+	}
+	waitForSync(np, synced, "pod deletion")
+
+	err = assertPolicies(np, npns1, 5, map[string]*npPolicy{
+		"allow-from-even": {
+			watchesNamespaces: true,
+			watchesAllPods:    true,
+			watchesOwnPods:    false,
+			ingressFlows: []string{
+				// no client in namespace 4
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[4])),
+				fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[6])),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[6])),
+				fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[8])),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[8])),
+				"reg0=4",
+				"reg0=6",
+				"reg0=8",
+			},
+		},
+		"allow-from-odd-primes": {
+			watchesNamespaces: true,
+			watchesAllPods:    true,
+			watchesOwnPods:    true,
+			ingressFlows: []string{
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[5])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[7])),
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	err = assertPolicies(np, np.namespaces[3], 3, map[string]*npPolicy{
+		"allow-client-to-server": {
+			watchesNamespaces: false,
+			watchesAllPods:    false,
+			watchesOwnPods:    true,
+			ingressFlows:      []string{},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	err = assertPolicies(np, np.namespaces[4], 2, map[string]*npPolicy{
+		"allow-client-to-server": {
+			watchesNamespaces: false,
+			watchesAllPods:    false,
+			watchesOwnPods:    true,
+			ingressFlows:      []string{},
 		},
 	})
 	if err != nil {

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -934,7 +934,7 @@ func TestNetworkPolicy(t *testing.T) {
 	}
 }
 
-func _TestNetworkPolicyInMigrationMode(t *testing.T) {
+func TestNetworkPolicyInMigrationMode(t *testing.T) {
 	np, _, synced, stopCh := newTestNPP()
 	defer close(stopCh)
 
@@ -1007,14 +1007,14 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 			"allow-from-self": {
 				watchesNamespaces: false,
 				watchesAllPods:    false,
-				watchesOwnPods:    false,
+				watchesOwnPods:    true,
 				ingressFlows: []string{
 					fmt.Sprintf("reg0=%d", npns.vnid),
 				},
 			},
 			"allow-from-default": {
 				watchesNamespaces: true,
-				watchesAllPods:    false,
+				watchesAllPods:    true,
 				watchesOwnPods:    false,
 				ingressFlows: []string{
 					"reg0=0",
@@ -1112,11 +1112,15 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 	err := assertPolicies(np, npns1, 4, map[string]*npPolicy{
 		"allow-from-even": {
 			watchesNamespaces: true,
-			watchesAllPods:    false,
+			watchesAllPods:    true,
 			watchesOwnPods:    false,
 			ingressFlows: []string{
-				"reg0=2",
-				"reg0=4",
+				fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[2])),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[2])),
+				fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[4])),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[4])),
+				"reg0=2, ",
+				"reg0=4, ",
 			},
 		},
 	})
@@ -1248,14 +1252,14 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 				"allow-from-self": {
 					watchesNamespaces: false,
 					watchesAllPods:    false,
-					watchesOwnPods:    false,
+					watchesOwnPods:    true,
 					ingressFlows: []string{
 						fmt.Sprintf("reg0=%d", vnid),
 					},
 				},
 				"allow-from-default": {
 					watchesNamespaces: true,
-					watchesAllPods:    false,
+					watchesAllPods:    true,
 					watchesOwnPods:    false,
 					ingressFlows: []string{
 						"reg0=0",
@@ -1271,14 +1275,16 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 				"allow-from-self": {
 					watchesNamespaces: false,
 					watchesAllPods:    false,
-					watchesOwnPods:    false,
+					watchesOwnPods:    true,
 					ingressFlows: []string{
+						fmt.Sprintf("ip, nw_src=%s", clientIP(npns)),
+						fmt.Sprintf("ip, nw_src=%s", serverIP(npns)),
 						"reg0=1",
 					},
 				},
 				"allow-from-default": {
 					watchesNamespaces: true,
-					watchesAllPods:    false,
+					watchesAllPods:    true,
 					watchesOwnPods:    false,
 					ingressFlows: []string{
 						"reg0=0",
@@ -1294,9 +1300,17 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 				},
 				"allow-from-even": {
 					watchesNamespaces: true,
-					watchesAllPods:    false,
+					watchesAllPods:    true,
 					watchesOwnPods:    false,
 					ingressFlows: []string{
+						fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[2])),
+						fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[2])),
+						fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[4])),
+						fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[4])),
+						fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[6])),
+						fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[6])),
+						fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[8])),
+						fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[8])),
 						"reg0=2",
 						"reg0=4",
 						"reg0=6",
@@ -1324,14 +1338,16 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 				"allow-from-self": {
 					watchesNamespaces: false,
 					watchesAllPods:    false,
-					watchesOwnPods:    false,
+					watchesOwnPods:    true,
 					ingressFlows: []string{
+						fmt.Sprintf("ip, nw_src=%s", clientIP(npns)),
+						fmt.Sprintf("ip, nw_src=%s", serverIP(npns)),
 						fmt.Sprintf("reg0=%d", vnid),
 					},
 				},
 				"allow-from-default": {
 					watchesNamespaces: true,
-					watchesAllPods:    false,
+					watchesAllPods:    true,
 					watchesOwnPods:    false,
 					ingressFlows: []string{
 						"reg0=0",
@@ -1371,14 +1387,16 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 				"allow-from-self": {
 					watchesNamespaces: false,
 					watchesAllPods:    false,
-					watchesOwnPods:    false,
+					watchesOwnPods:    true,
 					ingressFlows: []string{
+						fmt.Sprintf("ip, nw_src=%s", clientIP(npns)),
+						fmt.Sprintf("ip, nw_src=%s", serverIP(npns)),
 						fmt.Sprintf("reg0=%d", vnid),
 					},
 				},
 				"allow-from-default": {
 					watchesNamespaces: true,
-					watchesAllPods:    false,
+					watchesAllPods:    true,
 					watchesOwnPods:    false,
 					ingressFlows: []string{
 						"reg0=0",
@@ -1414,9 +1432,17 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 	err = assertPolicies(np, npns1, 5, map[string]*npPolicy{
 		"allow-from-even": {
 			watchesNamespaces: true,
-			watchesAllPods:    false,
+			watchesAllPods:    true,
 			watchesOwnPods:    false,
 			ingressFlows: []string{
+				fmt.Sprintf("ip, nw_src=%s", clientIP(npns2)),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(npns2)),
+				fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[4])),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[4])),
+				fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[6])),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[6])),
+				fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[8])),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[8])),
 				"reg0=2",
 				"reg0=4",
 				"reg0=6",
@@ -1435,9 +1461,15 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 	err = assertPolicies(np, npns1, 5, map[string]*npPolicy{
 		"allow-from-even": {
 			watchesNamespaces: true,
-			watchesAllPods:    false,
+			watchesAllPods:    true,
 			watchesOwnPods:    false,
 			ingressFlows: []string{
+				fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[4])),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[4])),
+				fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[6])),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[6])),
+				fmt.Sprintf("ip, nw_src=%s", clientIP(np.namespaces[8])),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(np.namespaces[8])),
 				"reg0=4",
 				"reg0=6",
 				"reg0=8",
@@ -1477,8 +1509,10 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 		"allow-from-self": {
 			watchesNamespaces: false,
 			watchesAllPods:    false,
-			watchesOwnPods:    false,
+			watchesOwnPods:    true,
 			ingressFlows: []string{
+				fmt.Sprintf("ip, nw_src=%s", clientIP(npns4)),
+				fmt.Sprintf("ip, nw_src=%s", serverIP(npns4)),
 				fmt.Sprintf("reg0=%d", npns4.vnid),
 			},
 		},
@@ -1498,164 +1532,10 @@ func _TestNetworkPolicyInMigrationMode(t *testing.T) {
 	err = assertPolicies(np, npns1, 5, map[string]*npPolicy{
 		"allow-from-default": {
 			watchesNamespaces: true,
-			watchesAllPods:    false,
+			watchesAllPods:    true,
 			watchesOwnPods:    false,
 			ingressFlows: []string{
 				"reg0=0",
-			},
-		},
-	})
-	if err != nil {
-		t.Error(err.Error())
-	}
-
-	// Create the special namespace that indicates host network traffic
-	addNamespace(np, "openshift-host-network", 200, map[string]string{"network.openshift.io/policy-group": "ingress"})
-	// Create the namespace to add network policy for
-	addNamespace(np, "host-network-target", 10, map[string]string{"foo": "bar"})
-	npns := np.namespaces[10]
-	synced.Store(false)
-	addNetworkPolicy(np, &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "allow-from-host-network-ns",
-			UID:       uid(npns, "allow-from-host-network-ns"),
-			Namespace: npns.name,
-		},
-		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{},
-			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{{
-				From: []networkingv1.NetworkPolicyPeer{{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"network.openshift.io/policy-group": "ingress",
-						},
-					},
-				}},
-			}},
-		},
-	})
-	waitForSync(np, synced, "host-network NP addition")
-
-	// make sure we add the right flows
-	err = assertPolicies(np, npns, 1, map[string]*npPolicy{
-		"allow-from-host-network-ns": {
-			watchesNamespaces: true,
-			watchesAllPods:    false,
-			watchesOwnPods:    false,
-			ingressFlows: []string{
-				"reg0=0", //make sure host network namespace is classified into vnid 0
-			},
-		},
-	})
-	if err != nil {
-		t.Error(err.Error())
-	}
-}
-
-func TestNetworkPolicyInMigrationMode(t *testing.T) {
-	var err error
-	np, _, synced, stopCh := newTestNPP()
-	np.inMigrationMode = true
-	_, clusterCIDR, _ := net.ParseCIDR("10.128.0.0/14")
-	np.node.networkInfo = &common.ParsedClusterNetwork{
-		ClusterNetworks: []common.ParsedClusterNetworkEntry{
-			{
-				ClusterCIDR:      clusterCIDR,
-				HostSubnetLength: 9,
-			},
-		},
-	}
-	defer close(stopCh)
-
-	// Create some Namespaces
-	addNamespace(np, "default", 0, map[string]string{"default": "true"})
-	addNamespace(np, "one", 1, map[string]string{"parity": "odd"})
-	addNamespace(np, "two", 2, map[string]string{"parity": "even"})
-
-	npns1 := np.namespaces[1]
-	npns2 := np.namespaces[2]
-
-	addPods(np, npns1)
-	addPods(np, npns2)
-
-	// Allow client pods in the same namespace to connect to the server in namespace "one"
-	synced.Store(false)
-	addNetworkPolicy(np, &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "allow-from-samenamespace",
-			UID:       uid(npns1, "allow-from-samenamespace"),
-			Namespace: "one",
-		},
-		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{},
-			},
-			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{{
-				From: []networkingv1.NetworkPolicyPeer{{
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{},
-					},
-				}},
-			}},
-		},
-	})
-	waitForSync(np, synced, "networkpolicy sync")
-
-	err = assertPolicies(np, npns1, 1, map[string]*npPolicy{
-		"allow-from-samenamespace": {
-			watchesNamespaces: false,
-			watchesAllPods:    false,
-			watchesOwnPods:    true,
-			ingressFlows: []string{
-				fmt.Sprintf("reg0=%d", npns1.vnid),
-				fmt.Sprintf("ip, nw_src=%s", clientIP(npns1)),
-				fmt.Sprintf("ip, nw_src=%s", serverIP(npns1)),
-			},
-		},
-	})
-	if err != nil {
-		t.Error(err.Error())
-	}
-
-	// Allow client pods in even namespaces to connect to the server in namespace "one"
-	synced.Store(false)
-	addNetworkPolicy(np, &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "allow-from-even",
-			UID:       uid(npns1, "allow-from-even"),
-			Namespace: "one",
-		},
-		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"kind": "server",
-				},
-			},
-			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{{
-				From: []networkingv1.NetworkPolicyPeer{{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"parity": "even",
-						},
-					},
-				}},
-			}},
-		},
-	})
-	waitForSync(np, synced, "networkpolicy sync")
-
-	err = assertPolicies(np, npns1, 2, map[string]*npPolicy{
-		"allow-from-even": {
-			watchesNamespaces: true,
-			watchesAllPods:    true,
-			watchesOwnPods:    true,
-			ingressFlows: []string{
-				fmt.Sprintf("ip, nw_dst=%s, reg0=%d", serverIP(npns1), npns2.vnid),
-				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns1), clientIP(npns2)),
-				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns1), serverIP(npns2)),
 			},
 		},
 	})

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -1076,6 +1076,7 @@ func TestNetworkPolicyInMigrationMode(t *testing.T) {
 				watchesAllPods:    true,
 				watchesOwnPods:    false,
 				ingressFlows: []string{
+					"ip, nw_src=10.128.0.2/255.252.1.255, ",
 					"reg0=0",
 				},
 			},
@@ -1321,6 +1322,7 @@ func TestNetworkPolicyInMigrationMode(t *testing.T) {
 					watchesAllPods:    true,
 					watchesOwnPods:    false,
 					ingressFlows: []string{
+						"ip, nw_src=10.128.0.2/255.252.1.255, ",
 						"reg0=0",
 					},
 				},
@@ -1346,6 +1348,7 @@ func TestNetworkPolicyInMigrationMode(t *testing.T) {
 					watchesAllPods:    true,
 					watchesOwnPods:    false,
 					ingressFlows: []string{
+						"ip, nw_src=10.128.0.2/255.252.1.255, ",
 						"reg0=0",
 					},
 				},
@@ -1409,6 +1412,7 @@ func TestNetworkPolicyInMigrationMode(t *testing.T) {
 					watchesAllPods:    true,
 					watchesOwnPods:    false,
 					ingressFlows: []string{
+						"ip, nw_src=10.128.0.2/255.252.1.255, ",
 						"reg0=0",
 					},
 				},
@@ -1458,6 +1462,7 @@ func TestNetworkPolicyInMigrationMode(t *testing.T) {
 					watchesAllPods:    true,
 					watchesOwnPods:    false,
 					ingressFlows: []string{
+						"ip, nw_src=10.128.0.2/255.252.1.255, ",
 						"reg0=0",
 					},
 				},
@@ -1594,6 +1599,7 @@ func TestNetworkPolicyInMigrationMode(t *testing.T) {
 			watchesAllPods:    true,
 			watchesOwnPods:    false,
 			ingressFlows: []string{
+				"ip, nw_src=10.128.0.2/255.252.1.255, ",
 				"reg0=0",
 			},
 		},

--- a/pkg/network/node/networkpolicy_test.go
+++ b/pkg/network/node/networkpolicy_test.go
@@ -934,6 +934,625 @@ func TestNetworkPolicy(t *testing.T) {
 	}
 }
 
+func _TestNetworkPolicyInMigrationMode(t *testing.T) {
+	np, _, synced, stopCh := newTestNPP()
+	defer close(stopCh)
+
+	np.inMigrationMode = true
+	_, clusterCIDR, _ := net.ParseCIDR("10.128.0.0/14")
+	np.node.networkInfo = &common.ParsedClusterNetwork{
+		ClusterNetworks: []common.ParsedClusterNetworkEntry{
+			{
+				ClusterCIDR:      clusterCIDR,
+				HostSubnetLength: 9,
+			},
+		},
+	}
+
+	// Create some Namespaces
+	addNamespace(np, "default", 0, map[string]string{"default": "true"})
+	addNamespace(np, "one", 1, map[string]string{"parity": "odd"})
+	addNamespace(np, "two", 2, map[string]string{"parity": "even", "prime": "true"})
+	addNamespace(np, "three", 3, map[string]string{"parity": "odd", "prime": "true"})
+	addNamespace(np, "four", 4, map[string]string{"parity": "even"})
+	addNamespace(np, "five", 5, map[string]string{"parity": "odd", "prime": "true"})
+
+	// Add allow-from-self and allow-from-default policies to all
+	for _, npns := range np.namespaces {
+		synced.Store(false)
+		addNetworkPolicy(np, &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-from-self",
+				UID:       uid(npns, "allow-from-self"),
+				Namespace: npns.name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{
+					From: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{},
+					}},
+				}},
+			},
+		})
+
+		synced.Store(false)
+		addNetworkPolicy(np, &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-from-default",
+				UID:       uid(npns, "allow-from-default"),
+				Namespace: npns.name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{
+					From: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"default": "true",
+							},
+						},
+					}},
+				}},
+			},
+		})
+	}
+	waitForSync(np, synced, "initialization")
+
+	// Each namespace should now have 2 policies, each with a single flow
+	for _, npns := range np.namespaces {
+		err := assertPolicies(np, npns, 2, map[string]*npPolicy{
+			"allow-from-self": {
+				watchesNamespaces: false,
+				watchesAllPods:    false,
+				watchesOwnPods:    false,
+				ingressFlows: []string{
+					fmt.Sprintf("reg0=%d", npns.vnid),
+				},
+			},
+			"allow-from-default": {
+				watchesNamespaces: true,
+				watchesAllPods:    false,
+				watchesOwnPods:    false,
+				ingressFlows: []string{
+					"reg0=0",
+				},
+			},
+		})
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+
+	// Add two pods to each namespace (except default)
+	for _, npns := range np.namespaces {
+		if npns.name == "default" {
+			continue
+		}
+
+		addPods(np, npns)
+
+		// There are no pod-selecting policies yet, so nothing should have changed
+		err := assertPolicies(np, npns, 2, nil)
+		if err != nil {
+			t.Error(err.Error())
+		}
+
+		synced.Store(false)
+		addNetworkPolicy(np, &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-client-to-server",
+				UID:       uid(npns, "allow-client-to-server"),
+				Namespace: npns.name,
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"kind": "server",
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{{
+					From: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kind": "client",
+							},
+						},
+					}},
+				}},
+			},
+		})
+		waitForSync(np, synced, "networkpolicy sync")
+
+		err = assertPolicies(np, npns, 3, map[string]*npPolicy{
+			"allow-client-to-server": {
+				watchesNamespaces: false,
+				watchesAllPods:    false,
+				watchesOwnPods:    true,
+				ingressFlows: []string{
+					fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
+				},
+			},
+		})
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
+
+	npns1 := np.namespaces[1]
+	npns2 := np.namespaces[2]
+
+	// Allow all pods in even-numbered namespaces to connect to any pod in namespace "one"
+	synced.Store(false)
+	addNetworkPolicy(np, &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-from-even",
+			UID:       uid(npns1, "allow-from-even"),
+			Namespace: "one",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"parity": "even",
+						},
+					},
+				}},
+			}},
+		},
+	})
+	waitForSync(np, synced, "networkpolicy sync")
+
+	err := assertPolicies(np, npns1, 4, map[string]*npPolicy{
+		"allow-from-even": {
+			watchesNamespaces: true,
+			watchesAllPods:    false,
+			watchesOwnPods:    false,
+			ingressFlows: []string{
+				"reg0=2",
+				"reg0=4",
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// Allow client pods in odd prime namespaces to connect to the server in namespace "one"
+	synced.Store(false)
+	addNetworkPolicy(np, &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-from-odd-primes",
+			UID:       uid(npns1, "allow-from-odd-primes"),
+			Namespace: "one",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kind": "server",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"parity": "odd",
+							"prime":  "true",
+						},
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kind": "client",
+						},
+					},
+				}},
+			}},
+		},
+	})
+	waitForSync(np, synced, "networkpolicy sync")
+
+	err = assertPolicies(np, npns1, 5, map[string]*npPolicy{
+		"allow-from-odd-primes": {
+			watchesNamespaces: true,
+			watchesAllPods:    true,
+			watchesOwnPods:    true,
+			ingressFlows: []string{
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[3])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns1), clientIP(np.namespaces[5])),
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// Allow client pods in all namespaces to connect to the server in namespace "two"
+	synced.Store(false)
+	addNetworkPolicy(np, &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-from-all-clients",
+			UID:       uid(npns1, "allow-from-all-clients"),
+			Namespace: "two",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kind": "server",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kind": "client",
+						},
+					},
+				}},
+			}},
+		},
+	})
+	waitForSync(np, synced, "networkpolicy sync")
+
+	err = assertPolicies(np, npns2, 4, map[string]*npPolicy{
+		"allow-from-all-clients": {
+			watchesNamespaces: true,
+			watchesAllPods:    true,
+			watchesOwnPods:    true,
+			ingressFlows: []string{
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[1])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[2])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[3])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[4])),
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns2), clientIP(np.namespaces[5])),
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// add some more namespaces
+	addNamespace(np, "six", 6, map[string]string{"parity": "even"})
+	addPods(np, np.namespaces[6])
+	addNamespace(np, "seven", 7, map[string]string{"parity": "odd", "prime": "true"})
+	addPods(np, np.namespaces[7])
+	addNamespace(np, "eight", 8, map[string]string{"parity": "even"})
+	addPods(np, np.namespaces[8])
+	addNamespace(np, "nine", 9, map[string]string{"parity": "odd"})
+	addPods(np, np.namespaces[9])
+
+	// add some non-pod-network pods; this should not affect the generated flows.
+	// (It should also not cause a sync but this is difficult to test since one of
+	// the previous calls may have resulted in two calls to np.syncNamespace()
+	// with the async runner triggering in between them, so there may still be
+	// another sync waiting to occur at this point.)
+	addBadPods(np, np.namespaces[4])
+	addBadPods(np, np.namespaces[7])
+	addBadPods(np, np.namespaces[9])
+
+	// Now reassert the full set of matches for each namespace
+	forceSync(np, synced)
+	for vnid, npns := range np.namespaces {
+		switch vnid {
+		case 0:
+			err := assertPolicies(np, npns, 2, map[string]*npPolicy{
+				"allow-from-self": {
+					watchesNamespaces: false,
+					watchesAllPods:    false,
+					watchesOwnPods:    false,
+					ingressFlows: []string{
+						fmt.Sprintf("reg0=%d", vnid),
+					},
+				},
+				"allow-from-default": {
+					watchesNamespaces: true,
+					watchesAllPods:    false,
+					watchesOwnPods:    false,
+					ingressFlows: []string{
+						"reg0=0",
+					},
+				},
+			})
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case 1:
+			err := assertPolicies(np, npns, 5, map[string]*npPolicy{
+				"allow-from-self": {
+					watchesNamespaces: false,
+					watchesAllPods:    false,
+					watchesOwnPods:    false,
+					ingressFlows: []string{
+						"reg0=1",
+					},
+				},
+				"allow-from-default": {
+					watchesNamespaces: true,
+					watchesAllPods:    false,
+					watchesOwnPods:    false,
+					ingressFlows: []string{
+						"reg0=0",
+					},
+				},
+				"allow-client-to-server": {
+					watchesNamespaces: false,
+					watchesAllPods:    false,
+					watchesOwnPods:    true,
+					ingressFlows: []string{
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
+					},
+				},
+				"allow-from-even": {
+					watchesNamespaces: true,
+					watchesAllPods:    false,
+					watchesOwnPods:    false,
+					ingressFlows: []string{
+						"reg0=2",
+						"reg0=4",
+						"reg0=6",
+						"reg0=8",
+					},
+				},
+				"allow-from-odd-primes": {
+					watchesNamespaces: true,
+					watchesAllPods:    true,
+					watchesOwnPods:    true,
+					ingressFlows: []string{
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[3])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[5])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[7])),
+						// but NOT from namespace 9
+					},
+				},
+			})
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case 2:
+			err := assertPolicies(np, npns, 4, map[string]*npPolicy{
+				"allow-from-self": {
+					watchesNamespaces: false,
+					watchesAllPods:    false,
+					watchesOwnPods:    false,
+					ingressFlows: []string{
+						fmt.Sprintf("reg0=%d", vnid),
+					},
+				},
+				"allow-from-default": {
+					watchesNamespaces: true,
+					watchesAllPods:    false,
+					watchesOwnPods:    false,
+					ingressFlows: []string{
+						"reg0=0",
+					},
+				},
+				"allow-client-to-server": {
+					watchesNamespaces: false,
+					watchesAllPods:    false,
+					watchesOwnPods:    true,
+					ingressFlows: []string{
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
+					},
+				},
+				"allow-from-all-clients": {
+					watchesNamespaces: true,
+					watchesAllPods:    true,
+					watchesOwnPods:    true,
+					ingressFlows: []string{
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[1])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[2])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[3])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[4])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[5])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[6])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[7])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[8])),
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(np.namespaces[9])),
+					},
+				},
+			})
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case 3, 4, 5:
+			err := assertPolicies(np, npns, 3, map[string]*npPolicy{
+				"allow-from-self": {
+					watchesNamespaces: false,
+					watchesAllPods:    false,
+					watchesOwnPods:    false,
+					ingressFlows: []string{
+						fmt.Sprintf("reg0=%d", vnid),
+					},
+				},
+				"allow-from-default": {
+					watchesNamespaces: true,
+					watchesAllPods:    false,
+					watchesOwnPods:    false,
+					ingressFlows: []string{
+						"reg0=0",
+					},
+				},
+				"allow-client-to-server": {
+					watchesNamespaces: false,
+					watchesAllPods:    false,
+					watchesOwnPods:    true,
+					ingressFlows: []string{
+						fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns), clientIP(npns)),
+					},
+				},
+			})
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case 6, 7, 8, 9:
+			err := assertPolicies(np, npns, 0, nil)
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		default:
+			t.Errorf("Unexpected namespace %d / %s", vnid, npns.name)
+		}
+	}
+
+	// If we delete a namespace, then stale policies may be left behind...
+	forceSync(np, synced)
+	delNamespace(np, "two", 2)
+	err = assertPolicies(np, npns1, 5, map[string]*npPolicy{
+		"allow-from-even": {
+			watchesNamespaces: true,
+			watchesAllPods:    false,
+			watchesOwnPods:    false,
+			ingressFlows: []string{
+				"reg0=2",
+				"reg0=4",
+				"reg0=6",
+				"reg0=8",
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// ...but they'll be cleaned up as soon as we add any new namespace
+	synced.Store(false)
+	addNamespace(np, "unrelated", 100, nil)
+	waitForSync(np, synced, "namespace addition")
+	err = assertPolicies(np, npns1, 5, map[string]*npPolicy{
+		"allow-from-even": {
+			watchesNamespaces: true,
+			watchesAllPods:    false,
+			watchesOwnPods:    false,
+			ingressFlows: []string{
+				"reg0=4",
+				"reg0=6",
+				"reg0=8",
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// Deleting a policy in one namespace will not affect other namespaces
+	npns4 := np.namespaces[4]
+	synced.Store(false)
+	delNetworkPolicy(np, &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-from-default",
+			UID:       uid(npns4, "allow-from-default"),
+			Namespace: npns4.name,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"default": "true",
+						},
+					},
+				}},
+			}},
+		},
+	})
+	waitForSync(np, synced, "namespace deletion")
+
+	err = assertPolicies(np, npns4, 2, map[string]*npPolicy{
+		"allow-from-self": {
+			watchesNamespaces: false,
+			watchesAllPods:    false,
+			watchesOwnPods:    false,
+			ingressFlows: []string{
+				fmt.Sprintf("reg0=%d", npns4.vnid),
+			},
+		},
+		"allow-client-to-server": {
+			watchesNamespaces: false,
+			watchesAllPods:    false,
+			watchesOwnPods:    true,
+			ingressFlows: []string{
+				fmt.Sprintf("ip, nw_dst=%s, ip, nw_src=%s", serverIP(npns4), clientIP(npns4)),
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	err = assertPolicies(np, npns1, 5, map[string]*npPolicy{
+		"allow-from-default": {
+			watchesNamespaces: true,
+			watchesAllPods:    false,
+			watchesOwnPods:    false,
+			ingressFlows: []string{
+				"reg0=0",
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// Create the special namespace that indicates host network traffic
+	addNamespace(np, "openshift-host-network", 200, map[string]string{"network.openshift.io/policy-group": "ingress"})
+	// Create the namespace to add network policy for
+	addNamespace(np, "host-network-target", 10, map[string]string{"foo": "bar"})
+	npns := np.namespaces[10]
+	synced.Store(false)
+	addNetworkPolicy(np, &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "allow-from-host-network-ns",
+			UID:       uid(npns, "allow-from-host-network-ns"),
+			Namespace: npns.name,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"network.openshift.io/policy-group": "ingress",
+						},
+					},
+				}},
+			}},
+		},
+	})
+	waitForSync(np, synced, "host-network NP addition")
+
+	// make sure we add the right flows
+	err = assertPolicies(np, npns, 1, map[string]*npPolicy{
+		"allow-from-host-network-ns": {
+			watchesNamespaces: true,
+			watchesAllPods:    false,
+			watchesOwnPods:    false,
+			ingressFlows: []string{
+				"reg0=0", //make sure host network namespace is classified into vnid 0
+			},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
 func TestNetworkPolicyInMigrationMode(t *testing.T) {
 	var err error
 	np, _, synced, stopCh := newTestNPP()


### PR DESCRIPTION
Normally in SDN, NetworkPolicies that match an entire namespace are implemented by matching the VNID, but this doesn't work during sdn->ovn migration, so they get rewritten to use pod IPs instead. The code for doing this is not really optimized, and particularly during migration (when every pod in the cluster gets deleted from its original node and then recreated on another) it results in the NP code doing a huge amount of work (and, seemingly, generating new garbage faster than the garbage collector can collect it).

This tries to mitigate the problem by only doing resyncs once every 10 seconds in migration mode (as opposed to once a second in non-migration mode). Hopefully this is enough to get the existing customers through migration. (If this does work I have other ideas, but they require rewriting a large chunk of code.)

(See also #650 for a more complicated, but maybe better, approach.)

/assign @pliurh 