### PR TITLE
[release-4.16] OCPBUGS-51017: Delete CNI configuration file when SDN pod is stopped

### DIFF
--- a/pkg/cmd/openshift-sdn-node/cmd.go
+++ b/pkg/cmd/openshift-sdn-node/cmd.go
@@ -2,11 +2,12 @@ package openshift_sdn_node
 
 import (
 	"fmt"
-	"github.com/spf13/pflag"
 	"io"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
@@ -120,6 +121,10 @@ func (sdn *openShiftSDN) run(c *cobra.Command, errout io.Writer, stopCh chan str
 	}
 
 	<-stopCh
+	err = sdn.deleteConfigFile()
+	if err != nil {
+		klog.Errorf("unable to delete sdn cni configuration file: %v", err)
+	}
 	time.Sleep(500 * time.Millisecond) // gracefully shut down
 }
 

--- a/pkg/cmd/openshift-sdn-node/sdn.go
+++ b/pkg/cmd/openshift-sdn-node/sdn.go
@@ -2,6 +2,7 @@ package openshift_sdn_node
 
 import (
 	"io/ioutil"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -55,4 +56,9 @@ func (sdn *openShiftSDN) writeConfigFile() error {
   "type": "openshift-sdn"
 }
 `), 0600)
+}
+
+func (sdn *openShiftSDN) deleteConfigFile() error {
+	// Delete CNI config file from disk if it's no longer able to serve CNI requests.
+	return os.Remove(openshiftCNIFile)
 }


### PR DESCRIPTION
The openshift sdn CNI configuration file `/etc/cni/net.d/80-openshift-network.conf` is written on the node upon first time of sdn pod deployment and remains to be there on the node during its lifetime. 
This makes multus to assume sdn is in ready state though sdn pod is coming up during reboot scenarios. Because of this, for a pod delete request, CNI DELETE request fails with connection refused error when sdn cni server socket is being created, this may end up in entries for the pod may not get cleaned up (example: IP address allocated for the pod by host-local IPAM plugin). 
Previously (4.13) this wasn't a problem because multus propagates the error for cni delete to crio/kubelet so that retries for delete happens for a failure, but this is not a case in 4.14 with this multus change: https://github.com/openshift/multus-cni/blob/release-4.14/pkg/server/api/shim.go#L68-L69.
This PR cleans up the cni config file when sdn pod is stopped. So when multus received cni delete request, it waits upto 45s (https://github.com/openshift/multus-cni/blob/release-4.14/pkg/multus/multus.go#L841-L845) until sdn plugin is actually ready and then delegate the request to sdn plugin.