### PR TITLE
OCPBUGS-54457: Drop SYNACK as well in MCS side

### DIFF
--- a/pkg/cmd/openshift-sdn-cni/openshift-sdn.go
+++ b/pkg/cmd/openshift-sdn-cni/openshift-sdn.go
@@ -133,7 +133,7 @@ func doNFTablesRules(platformType string) error {
 	tx.Add(&knftables.Rule{
 		Chain: "block",
 		Rule: knftables.Concat(
-			"tcp dport { 22623, 22624 } tcp flags syn",
+			"tcp dport { 22623, 22624 } tcp flags syn / fin,syn,rst,ack",
 			"reject",
 		),
 	})


### PR DESCRIPTION
When we converted MCS block rules from
iptables to nftables looks like match
criteria changed a bit.

Currently if a client from outside initiates
a connection and pod tries to send back synack
this is getting accepted by MCO(MCS metadata service) on the host instead of it going back to the client
because MCS rules is NOT rejecting a SYNACK packet.

old match: "tcp dport { 22623, 22624 } tcp flags syn" -> This matches TCP packets destined for ports 22623 or 22624 -> It matches packets that have only the SYN flag set -> This would not match both SYN and SYN+ACK packets because it only checks if the SYN flag is present

new match: "tcp dport { 22623, 22624 } tcp flags syn / fin,rst,ack" -> This matches TCP packets destined for ports 22623 or 22624 -> The / operator is a mask that requires the SYN flag to be set AND any of the other flags from the mask (FIN, RST, ACK) to be set -> This means it will match SYN, SYN+ACK, SYN+RST, SYN+FIN


same as https://github.com/openshift/ovn-kubernetes/pull/2240/files but for SDN